### PR TITLE
Fix: Preserve lastTransitionTime when condition status doesn't change

### DIFF
--- a/internal/controller/utils/conditions/conditions.go
+++ b/internal/controller/utils/conditions/conditions.go
@@ -31,7 +31,6 @@ func SetCondition(nebariApp *appsv1.NebariApp, conditionType string,
 
 	// Check if condition exists and if status is changing
 	existingCondition := meta.FindStatusCondition(nebariApp.Status.Conditions, conditionType)
-	now := metav1.Now()
 
 	condition := metav1.Condition{
 		Type:               conditionType,
@@ -42,11 +41,10 @@ func SetCondition(nebariApp *appsv1.NebariApp, conditionType string,
 	}
 
 	// Only set LastTransitionTime if condition doesn't exist or status is changing
+	// When status is not changing, leave LastTransitionTime unset (zero value)
+	// and meta.SetStatusCondition will preserve the existing value
 	if existingCondition == nil || existingCondition.Status != status {
-		condition.LastTransitionTime = now
-	} else {
-		// Preserve the existing LastTransitionTime
-		condition.LastTransitionTime = existingCondition.LastTransitionTime
+		condition.LastTransitionTime = metav1.Now()
 	}
 
 	meta.SetStatusCondition(&nebariApp.Status.Conditions, condition)


### PR DESCRIPTION
## Problem

The e2e test `should maintain lastTransitionTime when condition status doesn't change` was failing because the `SetCondition` function was updating `lastTransitionTime` even when the condition status remained the same.

The issue occurred because we were explicitly copying `lastTransitionTime` from the existing condition:
```go
condition.LastTransitionTime = existingCondition.LastTransitionTime
```

This could cause precision/serialization issues when the timestamp round-trips through the Kubernetes API server, making it appear as if the timestamp changed.

**Test Failure:**
```
Expected: 2026-02-12T15:56:46Z
Actual:   2026-02-12T15:56:47Z
```

## Solution

Instead of explicitly setting `lastTransitionTime` when the status hasn't changed, we now leave it as a zero value and let Kubernetes' `meta.SetStatusCondition` handle the preservation automatically.

**Key changes:**
- Only set `lastTransitionTime` when condition is new or status actually changes
- When status is unchanged, leave `lastTransitionTime` as zero value (default)
- `meta.SetStatusCondition` automatically preserves the existing timestamp from the conditions slice

## Testing

✅ All unit tests pass:
```bash
go test ./internal/controller/utils/conditions/... -v
```

✅ All controller tests pass:
```bash
go test ./internal/controller/... 
```

✅ Specific test validates the behavior:
- `TestSetCondition_PreservesLastTransitionTime` - verifies timestamp preservation when status doesn't change
- `TestSetCondition_UpdatesLastTransitionTimeOnStatusChange` - verifies timestamp updates on status transition

## Related

seen https://github.com/nebari-dev/nebari-operator/actions/runs/21953389827/job/63410646476?pr=26#logs

Fixes e2e test: `NebariApp Status Conditions Condition State Machine should maintain lastTransitionTime when condition status doesn't change`