### PR TITLE
Fix Keycloak install: remove duplicate KC_HTTP_RELATIVE_PATH

### DIFF
--- a/dev/scripts/services/keycloak/install.sh
+++ b/dev/scripts/services/keycloak/install.sh
@@ -79,8 +79,6 @@ extraEnv: |
     value: "admin"
   - name: KC_BOOTSTRAP_ADMIN_PASSWORD
     value: "admin"
-  - name: KC_HTTP_RELATIVE_PATH
-    value: "/auth"
   - name: JAVA_OPTS_APPEND
     value: "-Xms512m -Xmx1536m"
 


### PR DESCRIPTION
## Summary

- Remove duplicate `KC_HTTP_RELATIVE_PATH` from `extraEnv` in the Keycloak dev install script
- The `http.relativePath: "/auth"` value already causes the keycloakx chart to generate this env var automatically, so having it in `extraEnv` too creates a duplicate that Kubernetes rejects

## Root Cause

The error:
```
Error: failed to create typed patch object (keycloak/keycloak-keycloakx; apps/v1, Kind=StatefulSet):
  .spec.template.spec.containers[name="keycloak"].env: duplicate entries for key [name="KC_HTTP_RELATIVE_PATH"]
```

The codecentric/keycloakx chart converts `http.relativePath` into `KC_HTTP_RELATIVE_PATH` automatically. Setting it in both `extraEnv` and `http.relativePath` produces a duplicate.

## Fix

Remove the explicit `KC_HTTP_RELATIVE_PATH` entry from `extraEnv`. The `http.relativePath: "/auth"` setting is sufficient.

Fixes #55