### PR TITLE
feat: enable ForwardAccessToken on OIDC SecurityPolicies

### DIFF
--- a/internal/controller/reconcilers/auth/reconciler.go
+++ b/internal/controller/reconcilers/auth/reconciler.go
@@ -327,8 +327,9 @@ func (r *AuthReconciler) buildSecurityPolicySpec(ctx context.Context, nebariApp 
 			Name:      gwapiv1.ObjectName(clientSecretName),
 			Namespace: &secretNamespace,
 		},
-		RedirectURL: ptrTo(redirectURL),
-		LogoutPath:  ptrTo(constants.DefaultLogoutPath),
+		RedirectURL:        ptrTo(redirectURL),
+		LogoutPath:         ptrTo(constants.DefaultLogoutPath),
+		ForwardAccessToken: ptrTo(true),
 	}
 
 	// Set OIDC scopes

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -338,6 +338,9 @@ func TestBuildSecurityPolicySpec(t *testing.T) {
 				if len(spec.OIDC.Scopes) != 3 {
 					t.Errorf("expected 3 default scopes, got %d", len(spec.OIDC.Scopes))
 				}
+				if spec.OIDC.ForwardAccessToken == nil || !*spec.OIDC.ForwardAccessToken {
+					t.Error("expected ForwardAccessToken to be true")
+				}
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Adds `ForwardAccessToken: ptrTo(true)` to the OIDC config in `buildSecurityPolicySpec()`
- This makes Envoy Gateway forward the raw Keycloak access token as `Authorization: Bearer` header to upstream apps on authenticated routes
- Upstream apps can now identify users without parsing encrypted OIDC cookies (which Envoy Gateway encrypts by default since v1.6.0)

## Test plan
- [x] Unit test added asserting `ForwardAccessToken` is set to `true`
- [x] All existing tests pass
- [ ] Deploy to Hetzner cluster and verify `Authorization: Bearer` header arrives at upstream apps