### PR TITLE
feat: remove ForwardAccessToken, add app-level OIDC redirect URIs

### DIFF
--- a/internal/controller/reconcilers/auth/providers/keycloak.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak.go
@@ -329,6 +329,9 @@ func (p *KeycloakProvider) buildRedirectURLs(nebariApp *appsv1.NebariApp) []stri
 	return []string{
 		fmt.Sprintf("https://%s%s", nebariApp.Spec.Hostname, redirectPath),
 		fmt.Sprintf("http://%s%s", nebariApp.Spec.Hostname, redirectPath),
+		// Additional redirect URIs for app-level OIDC (browser and CLI login)
+		fmt.Sprintf("https://%s/api/v1/auth/oidc/callback", nebariApp.Spec.Hostname),
+		fmt.Sprintf("https://%s/api/v1/auth/cli-login/callback", nebariApp.Spec.Hostname),
 	}
 }
 

--- a/internal/controller/reconcilers/auth/providers/keycloak_test.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak_test.go
@@ -160,10 +160,12 @@ func TestKeycloakProvider_BuildRedirectURLs(t *testing.T) {
 					},
 				},
 			},
-			// buildRedirectURLs returns both HTTP and HTTPS for dev/prod support
+			// buildRedirectURLs returns HTTP/HTTPS plus app-level OIDC callbacks
 			expectedURLs: []string{
 				"https://test.example.com/oauth2/callback",
 				"http://test.example.com/oauth2/callback",
+				"https://test.example.com/api/v1/auth/oidc/callback",
+				"https://test.example.com/api/v1/auth/cli-login/callback",
 			},
 		},
 		{
@@ -184,6 +186,8 @@ func TestKeycloakProvider_BuildRedirectURLs(t *testing.T) {
 			expectedURLs: []string{
 				"https://test.example.com/custom/callback",
 				"http://test.example.com/custom/callback",
+				"https://test.example.com/api/v1/auth/oidc/callback",
+				"https://test.example.com/api/v1/auth/cli-login/callback",
 			},
 		},
 	}

--- a/internal/controller/reconcilers/auth/reconciler.go
+++ b/internal/controller/reconcilers/auth/reconciler.go
@@ -327,9 +327,8 @@ func (r *AuthReconciler) buildSecurityPolicySpec(ctx context.Context, nebariApp 
 			Name:      gwapiv1.ObjectName(clientSecretName),
 			Namespace: &secretNamespace,
 		},
-		RedirectURL:        ptrTo(redirectURL),
-		LogoutPath:         ptrTo(constants.DefaultLogoutPath),
-		ForwardAccessToken: ptrTo(true),
+		RedirectURL: ptrTo(redirectURL),
+		LogoutPath:  ptrTo(constants.DefaultLogoutPath),
 	}
 
 	// Set OIDC scopes

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -338,8 +338,8 @@ func TestBuildSecurityPolicySpec(t *testing.T) {
 				if len(spec.OIDC.Scopes) != 3 {
 					t.Errorf("expected 3 default scopes, got %d", len(spec.OIDC.Scopes))
 				}
-				if spec.OIDC.ForwardAccessToken == nil || !*spec.OIDC.ForwardAccessToken {
-					t.Error("expected ForwardAccessToken to be true")
+				if spec.OIDC.ForwardAccessToken != nil && *spec.OIDC.ForwardAccessToken {
+					t.Error("expected ForwardAccessToken to not be set")
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

- Remove `ForwardAccessToken: ptrTo(true)` from OIDC SecurityPolicy config — this was overwriting app Bearer tokens, breaking both Nebi and JupyterHub
- Add app-level OIDC redirect URIs to `buildRedirectURLs()` so Nebi can use the same Keycloak client for its own direct OIDC login:
  - `https://<hostname>/api/v1/auth/oidc/callback` (browser login)
  - `https://<hostname>/api/v1/auth/cli-login/callback` (CLI device code flow)

## Test plan

- [ ] Verify operator auth reconciler tests pass
- [ ] Deploy and confirm JupyterHub is no longer broken (ForwardAccessToken reverted)
- [ ] Verify Keycloak client gets updated with new redirect URIs on reconciliation
- [ ] Test Nebi direct OIDC login flow end-to-end