### PR TITLE
feat: add SPA client support for browser-based PKCE authentication

### DIFF
--- a/api/v1/nebariapp_types.go
+++ b/api/v1/nebariapp_types.go
@@ -203,6 +203,18 @@ type AuthConfig struct {
 	// +optional
 	IssuerURL string `json:"issuerURL,omitempty"`
 
+	// SPAClient configures a public OIDC client for browser-based authentication.
+	// When enabled, the operator provisions a separate public client for Single-Page
+	// Applications that use PKCE flows (e.g., React apps with keycloak-js).
+	// This is distinct from the confidential client used for server-side auth (oauth2-proxy).
+	// The public client is configured with:
+	//   - publicClient: true (no client secret, safe for browser)
+	//   - Redirect URIs: https://<hostname>/* and https://<hostname>
+	//   - PKCE enforcement (S256)
+	// Only supported for provider="keycloak".
+	// +optional
+	SPAClient *SPAClientConfig `json:"spaClient,omitempty"`
+
 	// KeycloakConfig provides Keycloak-specific configuration for fine-grained control
 	// over realm resources like groups, client scopes, and protocol mappers.
 	// Only used when provider="keycloak" and provisionClient=true; silently ignored
@@ -261,6 +273,29 @@ type KeycloakProtocolMapperConfig struct {
 	// Example for group-membership mapper: {"claim.name": "groups", "full.path": "false"}
 	// +optional
 	Config map[string]string `json:"config,omitempty"`
+}
+
+// SPAClientConfig specifies configuration for provisioning a public OIDC client
+// for Single-Page Applications (SPA) that use browser-based authentication with PKCE.
+// This client is separate from the confidential client used by oauth2-proxy or similar
+// server-side auth handlers.
+type SPAClientConfig struct {
+	// Enabled determines whether a public OIDC client should be provisioned for SPA use.
+	// When true, the operator creates a second Keycloak client configured as:
+	//   - publicClient: true (no client secret, safe for browser)
+	//   - Redirect URIs: https://<hostname>/* and https://<hostname>
+	//   - PKCE enforcement with S256 code challenge method
+	// The public client ID will be written to a ConfigMap or the OIDC secret for
+	// runtime consumption by the frontend application.
+	// +kubebuilder:default=false
+	// +optional
+	Enabled bool `json:"enabled,omitempty"`
+
+	// ClientID optionally overrides the generated client ID for the SPA client.
+	// If not specified, defaults to: <namespace>-<name>-spa
+	// This allows custom client naming for organizational conventions.
+	// +optional
+	ClientID string `json:"clientId,omitempty"`
 }
 
 // LandingPageConfig defines how a service appears on the Nebari landing page.

--- a/api/v1/nebariapp_types_test.go
+++ b/api/v1/nebariapp_types_test.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2026, OpenTeams.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSPAClientConfig_Defaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected SPAClientConfig
+	}{
+		{
+			name: "SPAClient enabled without custom clientID",
+			input: `{
+				"enabled": true
+			}`,
+			expected: SPAClientConfig{
+				Enabled:  true,
+				ClientID: "",
+			},
+		},
+		{
+			name: "SPAClient enabled with custom clientID",
+			input: `{
+				"enabled": true,
+				"clientId": "my-custom-spa-client"
+			}`,
+			expected: SPAClientConfig{
+				Enabled:  true,
+				ClientID: "my-custom-spa-client",
+			},
+		},
+		{
+			name: "SPAClient disabled",
+			input: `{
+				"enabled": false
+			}`,
+			expected: SPAClientConfig{
+				Enabled: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config SPAClientConfig
+			err := json.Unmarshal([]byte(tt.input), &config)
+			if err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			if config.Enabled != tt.expected.Enabled {
+				t.Errorf("Enabled: expected %v, got %v", tt.expected.Enabled, config.Enabled)
+			}
+			if config.ClientID != tt.expected.ClientID {
+				t.Errorf("ClientID: expected %q, got %q", tt.expected.ClientID, config.ClientID)
+			}
+		})
+	}
+}
+
+func TestAuthConfig_WithSPAClient(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		validate func(t *testing.T, auth AuthConfig)
+	}{
+		{
+			name: "Auth with both confidential and SPA client",
+			input: `{
+				"enabled": true,
+				"provider": "keycloak",
+				"redirectURI": "/oauth2/callback",
+				"spaClient": {
+					"enabled": true,
+					"clientId": "my-app-spa"
+				}
+			}`,
+			validate: func(t *testing.T, auth AuthConfig) {
+				if !auth.Enabled {
+					t.Error("Expected auth.Enabled to be true")
+				}
+				if auth.Provider != "keycloak" {
+					t.Errorf("Expected provider to be 'keycloak', got %q", auth.Provider)
+				}
+				if auth.SPAClient == nil {
+					t.Fatal("Expected SPAClient to be non-nil")
+				}
+				if !auth.SPAClient.Enabled {
+					t.Error("Expected SPAClient.Enabled to be true")
+				}
+				if auth.SPAClient.ClientID != "my-app-spa" {
+					t.Errorf("Expected SPAClient.ClientID to be 'my-app-spa', got %q", auth.SPAClient.ClientID)
+				}
+			},
+		},
+		{
+			name: "Auth without SPA client",
+			input: `{
+				"enabled": true,
+				"provider": "keycloak"
+			}`,
+			validate: func(t *testing.T, auth AuthConfig) {
+				if auth.SPAClient != nil {
+					t.Error("Expected SPAClient to be nil when not specified")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var auth AuthConfig
+			err := json.Unmarshal([]byte(tt.input), &auth)
+			if err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, auth)
+			}
+		})
+	}
+}
+
+func TestNebariAppSpec_WithSPAClient(t *testing.T) {
+	tests := []struct {
+		name      string
+		nebariApp *NebariApp
+		validate  func(t *testing.T, app *NebariApp)
+	}{
+		{
+			name: "Complete NebariApp with SPA client configuration",
+			nebariApp: &NebariApp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: NebariAppSpec{
+					Hostname: "test-app.nebari.local",
+					Service: ServiceReference{
+						Name: "test-service",
+						Port: 8080,
+					},
+					Auth: &AuthConfig{
+						Enabled:  true,
+						Provider: "keycloak",
+						SPAClient: &SPAClientConfig{
+							Enabled:  true,
+							ClientID: "test-app-spa",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, app *NebariApp) {
+				if app.Spec.Auth == nil {
+					t.Fatal("Expected Spec.Auth to be non-nil")
+				}
+				if app.Spec.Auth.SPAClient == nil {
+					t.Fatal("Expected Spec.Auth.SPAClient to be non-nil")
+				}
+				if !app.Spec.Auth.SPAClient.Enabled {
+					t.Error("Expected SPAClient.Enabled to be true")
+				}
+				if app.Spec.Auth.SPAClient.ClientID != "test-app-spa" {
+					t.Errorf("Expected SPAClient.ClientID to be 'test-app-spa', got %q", app.Spec.Auth.SPAClient.ClientID)
+				}
+			},
+		},
+		{
+			name: "NebariApp with enforceAtGateway=false and SPA client enabled",
+			nebariApp: &NebariApp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana-app",
+					Namespace: "default",
+				},
+				Spec: NebariAppSpec{
+					Hostname: "grafana.nebari.local",
+					Service: ServiceReference{
+						Name: "grafana",
+						Port: 3000,
+					},
+					Auth: &AuthConfig{
+						Enabled:          true,
+						Provider:         "keycloak",
+						EnforceAtGateway: boolPtr(false),
+						SPAClient: &SPAClientConfig{
+							Enabled:  true,
+							ClientID: "grafana-spa",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, app *NebariApp) {
+				if app.Spec.Auth == nil {
+					t.Fatal("Expected Spec.Auth to be non-nil")
+				}
+				if app.Spec.Auth.EnforceAtGateway == nil {
+					t.Fatal("Expected EnforceAtGateway to be non-nil")
+				}
+				if *app.Spec.Auth.EnforceAtGateway {
+					t.Error("Expected EnforceAtGateway to be false")
+				}
+				if app.Spec.Auth.SPAClient == nil {
+					t.Fatal("Expected Spec.Auth.SPAClient to be non-nil")
+				}
+				if !app.Spec.Auth.SPAClient.Enabled {
+					t.Error("Expected SPAClient.Enabled to be true")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Marshal and unmarshal to ensure JSON serialization works
+			data, err := json.Marshal(tt.nebariApp)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+
+			var decoded NebariApp
+			err = json.Unmarshal(data, &decoded)
+			if err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, &decoded)
+			}
+		})
+	}
+}
+
+func TestSPAClientConfig_JSONSerialization(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *SPAClientConfig
+	}{
+		{
+			name: "Enabled SPA client with custom ID",
+			config: &SPAClientConfig{
+				Enabled:  true,
+				ClientID: "custom-spa-client",
+			},
+		},
+		{
+			name: "Disabled SPA client",
+			config: &SPAClientConfig{
+				Enabled: false,
+			},
+		},
+		{
+			name: "Enabled without custom ID",
+			config: &SPAClientConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.config)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+
+			// Test round-trip
+			var decoded SPAClientConfig
+			err = json.Unmarshal(data, &decoded)
+			if err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			if tt.config.Enabled != decoded.Enabled {
+				t.Errorf("Enabled mismatch: expected %v, got %v", tt.config.Enabled, decoded.Enabled)
+			}
+			if tt.config.ClientID != decoded.ClientID {
+				t.Errorf("ClientID mismatch: expected %q, got %q", tt.config.ClientID, decoded.ClientID)
+			}
+		})
+	}
+}
+
+// boolPtr is a helper function to create a pointer to a bool
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/spf13/cobra v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 // indirect


### PR DESCRIPTION
## Summary

Adds support for dual-client OIDC provisioning to enable apps with React/SPA frontends to use browser-based authentication with PKCE alongside server-side auth (oauth2-proxy).

## Problem

The NebariApp operator currently provisions a single confidential OIDC client for server-side auth handlers like oauth2-proxy. When an app also serves a React/SPA frontend that uses keycloak-js directly in the browser with PKCE flow, a second separate Keycloak client is required with different configuration:

- **Confidential client** (existing): For oauth2-proxy with `/oauth2/callback` redirect URI
- **Public client** (new): For browser-based PKCE with wildcard redirect URIs

These cannot be merged: a confidential client rejects PKCE auth requests from the browser because the browser's redirect URI (the current page URL) doesn't match the narrow `/oauth2/callback` registered for oauth2-proxy.

## Solution

Added `SPAClientConfig` to `AuthConfig` spec:

```yaml
auth:
  enabled: true
  enforceAtGateway: false
  redirectURI: /oauth2/callback    # for oauth2-proxy (confidential client)
  spaClient:
    enabled: true                  # provisions a second public client
    clientId: custom-spa-client    # optional override; defaults to <namespace>-<name>-spa
```

## Changes

### API Changes

- Added `SPAClientConfig` struct with:
  - `enabled`: Controls provisioning of the public PKCE client
  - `clientId`: Optional override for the generated client ID (defaults to `<namespace>-<name>-spa`)
  
- Added `spaClient` field to `AuthConfig`

### Public Client Configuration

When `spaClient.enabled: true`, the operator will:
1. Create a second Keycloak client configured as:
   - `publicClient: true` (no client secret, safe for browser)
   - Redirect URIs: `https://<hostname>/*` and `https://<hostname>`
   - PKCE enforcement with S256 code challenge method
2. Write the public client ID to a ConfigMap or the OIDC secret for runtime consumption by the frontend

### Testing

- Added comprehensive unit tests for `SPAClientConfig`
- Tests cover JSON serialization, defaults, and integration with `AuthConfig` and `NebariAppSpec`
- All tests passing: `go test -v ./api/v1/...`

## Use Cases

### React App with Backend API
```yaml
apiVersion: reconcilers.nebari.dev/v1
kind: NebariApp
metadata:
  name: my-app
spec:
  hostname: app.nebari.local
  service:
    name: my-app-service
    port: 8080
  auth:
    enabled: true
    provider: keycloak
    redirectURI: /oauth2/callback  # backend auth via oauth2-proxy
    spaClient:
      enabled: true                 # frontend auth via keycloak-js
```

### Grafana with Custom Frontend
```yaml
apiVersion: reconcilers.nebari.dev/v1
kind: NebariApp
metadata:
  name: grafana
spec:
  hostname: grafana.nebari.local
  service:
    name: grafana
    port: 3000
  auth:
    enabled: true
    provider: keycloak
    enforceAtGateway: false         # Grafana handles OAuth natively
    spaClient:
      enabled: true
      clientId: grafana-spa
```

## Security Model

- **Confidential client**: Secret-based, narrow redirect URI
- **Public client**: PKCE-based (RFC 8252), wildcard redirect URIs safe because PKCE prevents token interception

## Next Steps

Controller implementation will:
1. Detect `spaClient.enabled: true`
2. Provision public client in Keycloak with appropriate config
3. Store public client ID in Secret/ConfigMap
4. Handle lifecycle (create, update, delete)

## Related

- Addresses use case for apps with React frontends using keycloak-js
- Follows OAuth 2.0 for Browser-Based Apps (RFC 8252) best practices
- Maintains backward compatibility (opt-in feature)