### PR TITLE
Fix OIDC token exchange TLS failure by using internal token endpoint

### DIFF
--- a/internal/controller/reconcilers/auth/providers/generic_oidc.go
+++ b/internal/controller/reconcilers/auth/providers/generic_oidc.go
@@ -37,6 +37,12 @@ func (p *GenericOIDCProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv
 	return nebariApp.Spec.Auth.IssuerURL, nil
 }
 
+// GetTokenEndpoint returns empty string for generic OIDC providers.
+// The token endpoint will be discovered from the OIDC provider's well-known configuration.
+func (p *GenericOIDCProvider) GetTokenEndpoint(ctx context.Context, nebariApp *appsv1.NebariApp) string {
+	return ""
+}
+
 // GetExternalIssuerURL returns the same URL as GetIssuerURL for generic OIDC.
 // Generic OIDC issuer URLs are already externally routable by definition.
 func (p *GenericOIDCProvider) GetExternalIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {

--- a/internal/controller/reconcilers/auth/providers/generic_oidc.go
+++ b/internal/controller/reconcilers/auth/providers/generic_oidc.go
@@ -37,10 +37,11 @@ func (p *GenericOIDCProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv
 	return nebariApp.Spec.Auth.IssuerURL, nil
 }
 
-// GetTokenEndpoint returns empty string for generic OIDC providers.
-// The token endpoint will be discovered from the OIDC provider's well-known configuration.
-func (p *GenericOIDCProvider) GetTokenEndpoint(ctx context.Context, nebariApp *appsv1.NebariApp) string {
-	return ""
+// GetEndpointOverrides returns empty overrides for generic OIDC providers.
+// Generic OIDC issuers are externally routable by definition; Envoy can reach
+// the discovered endpoints directly, so no overrides are needed.
+func (p *GenericOIDCProvider) GetEndpointOverrides(_ context.Context, _ *appsv1.NebariApp) (OIDCEndpointOverrides, error) {
+	return OIDCEndpointOverrides{}, nil
 }
 
 // GetExternalIssuerURL returns the same URL as GetIssuerURL for generic OIDC.

--- a/internal/controller/reconcilers/auth/providers/generic_oidc_test.go
+++ b/internal/controller/reconcilers/auth/providers/generic_oidc_test.go
@@ -101,13 +101,20 @@ func TestGenericOIDCProvider_GetIssuerURL(t *testing.T) {
 	}
 }
 
-func TestGenericOIDCProvider_GetTokenEndpoint(t *testing.T) {
+func TestGenericOIDCProvider_GetEndpointOverrides(t *testing.T) {
 	provider := &GenericOIDCProvider{}
-	// Generic OIDC always returns empty — token endpoint is discovered from
-	// the provider's well-known configuration document.
-	got := provider.GetTokenEndpoint(context.Background(), nil)
-	if got != "" {
-		t.Errorf("expected empty token endpoint for generic OIDC, got %q", got)
+	got, err := provider.GetEndpointOverrides(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Token != nil {
+		t.Errorf("expected nil token endpoint for generic OIDC, got %q", *got.Token)
+	}
+	if got.Authorization != nil {
+		t.Errorf("expected nil authorization endpoint for generic OIDC, got %q", *got.Authorization)
+	}
+	if got.EndSession != nil {
+		t.Errorf("expected nil end session endpoint for generic OIDC, got %q", *got.EndSession)
 	}
 }
 

--- a/internal/controller/reconcilers/auth/providers/generic_oidc_test.go
+++ b/internal/controller/reconcilers/auth/providers/generic_oidc_test.go
@@ -101,6 +101,16 @@ func TestGenericOIDCProvider_GetIssuerURL(t *testing.T) {
 	}
 }
 
+func TestGenericOIDCProvider_GetTokenEndpoint(t *testing.T) {
+	provider := &GenericOIDCProvider{}
+	// Generic OIDC always returns empty — token endpoint is discovered from
+	// the provider's well-known configuration document.
+	got := provider.GetTokenEndpoint(context.Background(), nil)
+	if got != "" {
+		t.Errorf("expected empty token endpoint for generic OIDC, got %q", got)
+	}
+}
+
 func TestGenericOIDCProvider_GetClientID(t *testing.T) {
 	provider := &GenericOIDCProvider{}
 

--- a/internal/controller/reconcilers/auth/providers/keycloak.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak.go
@@ -48,7 +48,7 @@ type KeycloakProvider struct {
 }
 
 // internalRealmURL returns the base internal cluster URL for the Keycloak realm.
-// This is used by both GetIssuerURL and GetTokenEndpoint to avoid duplication.
+// This is used by both GetIssuerURL and GetEndpointOverrides to avoid duplication.
 func (p *KeycloakProvider) internalRealmURL() string {
 	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s/realms/%s",
 		p.Config.IssuerServiceName,
@@ -64,12 +64,19 @@ func (p *KeycloakProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.N
 	return p.internalRealmURL(), nil
 }
 
-// GetTokenEndpoint returns the internal cluster token endpoint URL for Keycloak.
-// This avoids Envoy using the external HTTPS token endpoint from the OIDC discovery
+// GetEndpointOverrides returns internal cluster URLs for Keycloak's OIDC endpoints.
+// This avoids Envoy using the external HTTPS endpoints from the OIDC discovery
 // document, which may use a certificate not trusted by Envoy (e.g., self-signed).
-func (p *KeycloakProvider) GetTokenEndpoint(ctx context.Context, nebariApp *appsv1.NebariApp) string {
-	return p.internalRealmURL() + "/protocol/openid-connect/token"
+func (p *KeycloakProvider) GetEndpointOverrides(_ context.Context, _ *appsv1.NebariApp) (OIDCEndpointOverrides, error) {
+	base := p.internalRealmURL() + "/protocol/openid-connect"
+	return OIDCEndpointOverrides{
+		Token:         ptrTo(base + "/token"),
+		Authorization: ptrTo(base + "/auth"),
+		EndSession:    ptrTo(base + "/logout"),
+	}, nil
 }
+
+func ptrTo(s string) *string { return &s }
 
 // GetExternalIssuerURL returns the publicly routable Keycloak issuer URL.
 func (p *KeycloakProvider) GetExternalIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {

--- a/internal/controller/reconcilers/auth/providers/keycloak.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak.go
@@ -47,18 +47,28 @@ type KeycloakProvider struct {
 	Config config.KeycloakConfig
 }
 
-// GetIssuerURL returns the internal cluster URL for the Keycloak realm.
-// Envoy uses this to fetch OIDC configuration from within the cluster.
-func (p *KeycloakProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {
-	realm := p.Config.Realm
-	// Use internal cluster DNS for Envoy to fetch OIDC config
-	// All components are now configurable via environment variables
+// internalRealmURL returns the base internal cluster URL for the Keycloak realm.
+// This is used by both GetIssuerURL and GetTokenEndpoint to avoid duplication.
+func (p *KeycloakProvider) internalRealmURL() string {
 	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s/realms/%s",
 		p.Config.IssuerServiceName,
 		p.Config.IssuerServiceNamespace,
 		p.Config.IssuerServicePort,
 		p.Config.IssuerContextPath,
-		realm), nil
+		p.Config.Realm)
+}
+
+// GetIssuerURL returns the internal cluster URL for the Keycloak realm.
+// Envoy uses this to fetch OIDC configuration from within the cluster.
+func (p *KeycloakProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {
+	return p.internalRealmURL(), nil
+}
+
+// GetTokenEndpoint returns the internal cluster token endpoint URL for Keycloak.
+// This avoids Envoy using the external HTTPS token endpoint from the OIDC discovery
+// document, which may use a certificate not trusted by Envoy (e.g., self-signed).
+func (p *KeycloakProvider) GetTokenEndpoint(ctx context.Context, nebariApp *appsv1.NebariApp) string {
+	return p.internalRealmURL() + "/protocol/openid-connect/token"
 }
 
 // GetExternalIssuerURL returns the publicly routable Keycloak issuer URL.

--- a/internal/controller/reconcilers/auth/providers/keycloak.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nebari-dev/nebari-operator/internal/config"
 	"github.com/nebari-dev/nebari-operator/internal/controller/utils/constants"
 	"github.com/nebari-dev/nebari-operator/internal/controller/utils/naming"
+	"github.com/nebari-dev/nebari-operator/internal/controller/utils/ptr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,13 +71,11 @@ func (p *KeycloakProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.N
 func (p *KeycloakProvider) GetEndpointOverrides(_ context.Context, _ *appsv1.NebariApp) (OIDCEndpointOverrides, error) {
 	base := p.internalRealmURL() + "/protocol/openid-connect"
 	return OIDCEndpointOverrides{
-		Token:         ptrTo(base + "/token"),
-		Authorization: ptrTo(base + "/auth"),
-		EndSession:    ptrTo(base + "/logout"),
+		Token:         ptr.To(base + "/token"),
+		Authorization: ptr.To(base + "/auth"),
+		EndSession:    ptr.To(base + "/logout"),
 	}, nil
 }
-
-func ptrTo(s string) *string { return &s }
 
 // GetExternalIssuerURL returns the publicly routable Keycloak issuer URL.
 func (p *KeycloakProvider) GetExternalIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {

--- a/internal/controller/reconcilers/auth/providers/keycloak_test.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak_test.go
@@ -117,11 +117,11 @@ func TestKeycloakProvider_GetIssuerURL(t *testing.T) {
 	}
 }
 
-func TestKeycloakProvider_GetTokenEndpoint(t *testing.T) {
+func TestKeycloakProvider_GetEndpointOverrides(t *testing.T) {
 	tests := []struct {
-		name        string
-		kcConfig    config.KeycloakConfig
-		expectedURL string
+		name     string
+		kcConfig config.KeycloakConfig
+		expected OIDCEndpointOverrides
 	}{
 		{
 			name: "Default configuration (Keycloak 26+ root context path)",
@@ -132,7 +132,11 @@ func TestKeycloakProvider_GetTokenEndpoint(t *testing.T) {
 				IssuerServicePort:      8080,
 				IssuerContextPath:      "",
 			},
-			expectedURL: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token",
+			expected: OIDCEndpointOverrides{
+				Token:         ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token"),
+				Authorization: ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/auth"),
+				EndSession:    ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/logout"),
+			},
 		},
 		{
 			name: "Legacy /auth context path",
@@ -143,7 +147,11 @@ func TestKeycloakProvider_GetTokenEndpoint(t *testing.T) {
 				IssuerServicePort:      8080,
 				IssuerContextPath:      "/auth",
 			},
-			expectedURL: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/token",
+			expected: OIDCEndpointOverrides{
+				Token:         ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/token"),
+				Authorization: ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/auth"),
+				EndSession:    ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/logout"),
+			},
 		},
 		{
 			name: "Custom deployment configuration",
@@ -154,16 +162,29 @@ func TestKeycloakProvider_GetTokenEndpoint(t *testing.T) {
 				IssuerServicePort:      9090,
 				IssuerContextPath:      "",
 			},
-			expectedURL: "http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/token",
+			expected: OIDCEndpointOverrides{
+				Token:         ptrTo("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/token"),
+				Authorization: ptrTo("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/auth"),
+				EndSession:    ptrTo("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/logout"),
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &KeycloakProvider{Config: tt.kcConfig}
-			got := provider.GetTokenEndpoint(context.Background(), nil)
-			if got != tt.expectedURL {
-				t.Errorf("expected %q, got %q", tt.expectedURL, got)
+			got, err := provider.GetEndpointOverrides(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Token == nil || *got.Token != *tt.expected.Token {
+				t.Errorf("token: expected %q, got %v", *tt.expected.Token, got.Token)
+			}
+			if got.Authorization == nil || *got.Authorization != *tt.expected.Authorization {
+				t.Errorf("authorization: expected %q, got %v", *tt.expected.Authorization, got.Authorization)
+			}
+			if got.EndSession == nil || *got.EndSession != *tt.expected.EndSession {
+				t.Errorf("endSession: expected %q, got %v", *tt.expected.EndSession, got.EndSession)
 			}
 		})
 	}

--- a/internal/controller/reconcilers/auth/providers/keycloak_test.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak_test.go
@@ -117,6 +117,58 @@ func TestKeycloakProvider_GetIssuerURL(t *testing.T) {
 	}
 }
 
+func TestKeycloakProvider_GetTokenEndpoint(t *testing.T) {
+	tests := []struct {
+		name        string
+		kcConfig    config.KeycloakConfig
+		expectedURL string
+	}{
+		{
+			name: "Default configuration (Keycloak 26+ root context path)",
+			kcConfig: config.KeycloakConfig{
+				Realm:                  "nebari",
+				IssuerServiceName:      "keycloak-keycloakx-http",
+				IssuerServiceNamespace: "keycloak",
+				IssuerServicePort:      8080,
+				IssuerContextPath:      "",
+			},
+			expectedURL: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token",
+		},
+		{
+			name: "Legacy /auth context path",
+			kcConfig: config.KeycloakConfig{
+				Realm:                  "nebari",
+				IssuerServiceName:      "keycloak-keycloakx-http",
+				IssuerServiceNamespace: "keycloak",
+				IssuerServicePort:      8080,
+				IssuerContextPath:      "/auth",
+			},
+			expectedURL: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/token",
+		},
+		{
+			name: "Custom deployment configuration",
+			kcConfig: config.KeycloakConfig{
+				Realm:                  "custom-realm",
+				IssuerServiceName:      "custom-keycloak",
+				IssuerServiceNamespace: "auth",
+				IssuerServicePort:      9090,
+				IssuerContextPath:      "",
+			},
+			expectedURL: "http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &KeycloakProvider{Config: tt.kcConfig}
+			got := provider.GetTokenEndpoint(context.Background(), nil)
+			if got != tt.expectedURL {
+				t.Errorf("expected %q, got %q", tt.expectedURL, got)
+			}
+		})
+	}
+}
+
 func TestKeycloakProvider_GetClientID(t *testing.T) {
 	provider := &KeycloakProvider{
 		Config: config.KeycloakConfig{

--- a/internal/controller/reconcilers/auth/providers/keycloak_test.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nebari-dev/nebari-operator/internal/config"
 	"github.com/nebari-dev/nebari-operator/internal/controller/utils/constants"
 	"github.com/nebari-dev/nebari-operator/internal/controller/utils/naming"
+	"github.com/nebari-dev/nebari-operator/internal/controller/utils/ptr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -133,9 +134,9 @@ func TestKeycloakProvider_GetEndpointOverrides(t *testing.T) {
 				IssuerContextPath:      "",
 			},
 			expected: OIDCEndpointOverrides{
-				Token:         ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token"),
-				Authorization: ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/auth"),
-				EndSession:    ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/logout"),
+				Token:         ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token"),
+				Authorization: ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/auth"),
+				EndSession:    ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/logout"),
 			},
 		},
 		{
@@ -148,9 +149,9 @@ func TestKeycloakProvider_GetEndpointOverrides(t *testing.T) {
 				IssuerContextPath:      "/auth",
 			},
 			expected: OIDCEndpointOverrides{
-				Token:         ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/token"),
-				Authorization: ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/auth"),
-				EndSession:    ptrTo("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/logout"),
+				Token:         ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/token"),
+				Authorization: ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/auth"),
+				EndSession:    ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/logout"),
 			},
 		},
 		{
@@ -163,9 +164,9 @@ func TestKeycloakProvider_GetEndpointOverrides(t *testing.T) {
 				IssuerContextPath:      "",
 			},
 			expected: OIDCEndpointOverrides{
-				Token:         ptrTo("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/token"),
-				Authorization: ptrTo("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/auth"),
-				EndSession:    ptrTo("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/logout"),
+				Token:         ptr.To("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/token"),
+				Authorization: ptr.To("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/auth"),
+				EndSession:    ptr.To("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/logout"),
 			},
 		},
 	}

--- a/internal/controller/reconcilers/auth/providers/provider.go
+++ b/internal/controller/reconcilers/auth/providers/provider.go
@@ -31,6 +31,12 @@ type OIDCProvider interface {
 	// The URL should be accessible from within the cluster (internal DNS).
 	GetIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error)
 
+	// GetTokenEndpoint returns an explicit token endpoint URL if needed.
+	// This is used when the OIDC discovery document returns an external URL
+	// that is not reachable from within the cluster (e.g., uses HTTPS with
+	// a certificate not trusted by Envoy). Returns empty string to use discovery.
+	GetTokenEndpoint(ctx context.Context, nebariApp *appsv1.NebariApp) string
+
 	// GetExternalIssuerURL returns the publicly routable OIDC issuer URL.
 	// Written to the client Secret for external consumers (CLIs, frontends).
 	// For Keycloak, uses KEYCLOAK_EXTERNAL_URL. For generic OIDC, same as GetIssuerURL.

--- a/internal/controller/reconcilers/auth/providers/provider.go
+++ b/internal/controller/reconcilers/auth/providers/provider.go
@@ -22,6 +22,15 @@ import (
 	appsv1 "github.com/nebari-dev/nebari-operator/api/v1"
 )
 
+// OIDCEndpointOverrides holds explicit OIDC endpoint URLs that override
+// the values obtained from the provider's discovery document. Nil fields
+// indicate that the discovered value should be used.
+type OIDCEndpointOverrides struct {
+	Token         *string
+	Authorization *string
+	EndSession    *string
+}
+
 // OIDCProvider defines the interface for OIDC provider implementations.
 // Each provider (Keycloak, generic OIDC, etc.) must implement this interface.
 type OIDCProvider interface {
@@ -31,11 +40,13 @@ type OIDCProvider interface {
 	// The URL should be accessible from within the cluster (internal DNS).
 	GetIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error)
 
-	// GetTokenEndpoint returns an explicit token endpoint URL if needed.
-	// This is used when the OIDC discovery document returns an external URL
-	// that is not reachable from within the cluster (e.g., uses HTTPS with
-	// a certificate not trusted by Envoy). Returns empty string to use discovery.
-	GetTokenEndpoint(ctx context.Context, nebariApp *appsv1.NebariApp) string
+	// GetEndpointOverrides returns explicit OIDC endpoint URLs that should
+	// override the values from the provider's discovery document. This is
+	// used when the discovery document returns external URLs that are not
+	// reachable from within the cluster (e.g., HTTPS with a certificate not
+	// trusted by Envoy). Any non-nil field must be a complete absolute URL
+	// reachable from within the cluster. Nil fields fall back to discovery.
+	GetEndpointOverrides(ctx context.Context, nebariApp *appsv1.NebariApp) (OIDCEndpointOverrides, error)
 
 	// GetExternalIssuerURL returns the publicly routable OIDC issuer URL.
 	// Written to the client Secret for external consumers (CLIs, frontends).

--- a/internal/controller/reconcilers/auth/reconciler.go
+++ b/internal/controller/reconcilers/auth/reconciler.go
@@ -443,10 +443,20 @@ func (r *AuthReconciler) buildSecurityPolicySpec(ctx context.Context, nebariApp 
 	secretNamespace := gwapiv1.Namespace(nebariApp.Namespace)
 
 	// Build OIDC configuration
+	oidcProvider := egv1alpha1.OIDCProvider{
+		Issuer: issuerURL,
+	}
+
+	// Set explicit token endpoint if the provider returns one.
+	// This ensures Envoy uses the internal cluster URL for the token exchange
+	// instead of the external URL from the OIDC discovery document, which may
+	// use a TLS certificate not trusted by Envoy.
+	if tokenEndpoint := provider.GetTokenEndpoint(ctx, nebariApp); tokenEndpoint != "" {
+		oidcProvider.TokenEndpoint = ptrTo(tokenEndpoint)
+	}
+
 	oidcConfig := &egv1alpha1.OIDC{
-		Provider: egv1alpha1.OIDCProvider{
-			Issuer: issuerURL,
-		},
+		Provider: oidcProvider,
 		ClientID: ptrTo(clientID),
 		ClientSecret: gwapiv1.SecretObjectReference{
 			Group:     &secretGroup,

--- a/internal/controller/reconcilers/auth/reconciler.go
+++ b/internal/controller/reconcilers/auth/reconciler.go
@@ -447,12 +447,24 @@ func (r *AuthReconciler) buildSecurityPolicySpec(ctx context.Context, nebariApp 
 		Issuer: issuerURL,
 	}
 
-	// Set explicit token endpoint if the provider returns one.
-	// This ensures Envoy uses the internal cluster URL for the token exchange
-	// instead of the external URL from the OIDC discovery document, which may
-	// use a TLS certificate not trusted by Envoy.
-	if tokenEndpoint := provider.GetTokenEndpoint(ctx, nebariApp); tokenEndpoint != "" {
-		oidcProvider.TokenEndpoint = ptrTo(tokenEndpoint)
+	// Apply explicit endpoint overrides from the provider. This ensures Envoy
+	// uses internal cluster URLs instead of external URLs from the OIDC discovery
+	// document, which may use TLS certificates not trusted by Envoy.
+	overrides, err := provider.GetEndpointOverrides(ctx, nebariApp)
+	if err != nil {
+		return egv1alpha1.SecurityPolicySpec{}, fmt.Errorf("failed to get endpoint overrides: %w", err)
+	}
+	if overrides.Token != nil {
+		log.FromContext(ctx).Info("Overriding OIDC endpoint from discovery", "endpoint", "token", "url", *overrides.Token)
+		oidcProvider.TokenEndpoint = overrides.Token
+	}
+	if overrides.Authorization != nil {
+		log.FromContext(ctx).Info("Overriding OIDC endpoint from discovery", "endpoint", "authorization", "url", *overrides.Authorization)
+		oidcProvider.AuthorizationEndpoint = overrides.Authorization
+	}
+	if overrides.EndSession != nil {
+		log.FromContext(ctx).Info("Overriding OIDC endpoint from discovery", "endpoint", "endSession", "url", *overrides.EndSession)
+		oidcProvider.EndSessionEndpoint = overrides.EndSession
 	}
 
 	oidcConfig := &egv1alpha1.OIDC{

--- a/internal/controller/reconcilers/auth/reconciler.go
+++ b/internal/controller/reconcilers/auth/reconciler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nebari-dev/nebari-operator/internal/controller/utils/conditions"
 	"github.com/nebari-dev/nebari-operator/internal/controller/utils/constants"
 	"github.com/nebari-dev/nebari-operator/internal/controller/utils/naming"
+	"github.com/nebari-dev/nebari-operator/internal/controller/utils/ptr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -469,15 +470,15 @@ func (r *AuthReconciler) buildSecurityPolicySpec(ctx context.Context, nebariApp 
 
 	oidcConfig := &egv1alpha1.OIDC{
 		Provider: oidcProvider,
-		ClientID: ptrTo(clientID),
+		ClientID: ptr.To(clientID),
 		ClientSecret: gwapiv1.SecretObjectReference{
 			Group:     &secretGroup,
 			Kind:      &secretKind,
 			Name:      gwapiv1.ObjectName(clientSecretName),
 			Namespace: &secretNamespace,
 		},
-		RedirectURL: ptrTo(redirectURL),
-		LogoutPath:  ptrTo(constants.DefaultLogoutPath),
+		RedirectURL: ptr.To(redirectURL),
+		LogoutPath:  ptr.To(constants.DefaultLogoutPath),
 	}
 
 	// Set OIDC scopes
@@ -581,8 +582,4 @@ func (r *AuthReconciler) reconcileTokenExchange(ctx context.Context, nebariApp *
 	}
 
 	return provider.ConfigureTokenExchange(ctx, nebariApp, peerClientIDs)
-}
-
-func ptrTo[T any](v T) *T {
-	return &v
 }

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -687,7 +687,7 @@ func TestReconcileAuth(t *testing.T) {
 			},
 			provider: &mockProvider{
 				issuerURL:            "https://keycloak.example.com/realms/test",
-				tokenEndpoint:        "http://keycloak.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token",
+				tokenEndpoint:        "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token",
 				clientID:             "test-client",
 				supportsProvisioning: true,
 			},

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-
 // verifyEndpointOverrides checks that the SecurityPolicy's endpoint overrides match expectations.
 func verifyEndpointOverrides(t *testing.T, sp *egv1alpha1.SecurityPolicy, expected providers.OIDCEndpointOverrides) {
 	t.Helper()

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -36,6 +36,19 @@ import (
 )
 
 // boolPtr returns a pointer to a bool value
+// verifyTokenEndpoint checks that the SecurityPolicy's token endpoint matches expectations.
+func verifyTokenEndpoint(t *testing.T, sp *egv1alpha1.SecurityPolicy, expected string) {
+	t.Helper()
+	actual := sp.Spec.OIDC.Provider.TokenEndpoint
+	if expected != "" {
+		if actual == nil || *actual != expected {
+			t.Errorf("expected token endpoint %q, got %v", expected, actual)
+		}
+	} else if actual != nil {
+		t.Errorf("expected no explicit token endpoint, got %q", *actual)
+	}
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }
@@ -1044,19 +1057,7 @@ func TestReconcileAuth(t *testing.T) {
 					if err != nil {
 						t.Errorf("expected SecurityPolicy to be created, got error: %v", err)
 					} else if securityPolicy.Spec.OIDC != nil {
-						// Verify token endpoint matches provider's GetTokenEndpoint
-						tokenEndpoint := tt.provider.GetTokenEndpoint(context.Background(), tt.nebariApp)
-						if tokenEndpoint != "" {
-							if securityPolicy.Spec.OIDC.Provider.TokenEndpoint == nil {
-								t.Error("expected SecurityPolicy to have explicit token endpoint set")
-							} else if *securityPolicy.Spec.OIDC.Provider.TokenEndpoint != tokenEndpoint {
-								t.Errorf("expected token endpoint %q, got %q", tokenEndpoint, *securityPolicy.Spec.OIDC.Provider.TokenEndpoint)
-							}
-						} else {
-							if securityPolicy.Spec.OIDC.Provider.TokenEndpoint != nil {
-								t.Errorf("expected no explicit token endpoint, got %q", *securityPolicy.Spec.OIDC.Provider.TokenEndpoint)
-							}
-						}
+						verifyTokenEndpoint(t, securityPolicy, tt.provider.GetTokenEndpoint(context.Background(), tt.nebariApp))
 					}
 				} else {
 					if err == nil {

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nebari-dev/nebari-operator/internal/controller/reconcilers/auth/providers"
 	"github.com/nebari-dev/nebari-operator/internal/controller/utils/constants"
 	"github.com/nebari-dev/nebari-operator/internal/controller/utils/naming"
+	"github.com/nebari-dev/nebari-operator/internal/controller/utils/ptr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,14 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// boolPtr returns a pointer to a bool value.
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func strPtr(s string) *string {
-	return &s
-}
 
 // verifyEndpointOverrides checks that the SecurityPolicy's endpoint overrides match expectations.
 func verifyEndpointOverrides(t *testing.T, sp *egv1alpha1.SecurityPolicy, expected providers.OIDCEndpointOverrides) {
@@ -675,7 +668,7 @@ func TestReconcileAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:         true,
 						Provider:        constants.ProviderKeycloak,
-						ProvisionClient: boolPtr(false),
+						ProvisionClient: ptr.To(false),
 					},
 				},
 			},
@@ -707,7 +700,7 @@ func TestReconcileAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:         true,
 						Provider:        constants.ProviderKeycloak,
-						ProvisionClient: boolPtr(false),
+						ProvisionClient: ptr.To(false),
 					},
 				},
 			},
@@ -723,17 +716,17 @@ func TestReconcileAuth(t *testing.T) {
 			provider: &mockProvider{
 				issuerURL: "https://keycloak.example.com/realms/test",
 				endpointOverrides: providers.OIDCEndpointOverrides{
-					Token:         strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token"),
-					Authorization: strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/auth"),
-					EndSession:    strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/logout"),
+					Token:         ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token"),
+					Authorization: ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/auth"),
+					EndSession:    ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/logout"),
 				},
 				clientID:             "test-client",
 				supportsProvisioning: true,
 			},
 			expectedOverrides: providers.OIDCEndpointOverrides{
-				Token:         strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token"),
-				Authorization: strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/auth"),
-				EndSession:    strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/logout"),
+				Token:         ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token"),
+				Authorization: ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/auth"),
+				EndSession:    ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/logout"),
 			},
 			expectError: false,
 		},
@@ -749,7 +742,7 @@ func TestReconcileAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:         true,
 						Provider:        constants.ProviderKeycloak,
-						ProvisionClient: boolPtr(false),
+						ProvisionClient: ptr.To(false),
 					},
 				},
 			},
@@ -782,7 +775,7 @@ func TestReconcileAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:         true,
 						Provider:        constants.ProviderKeycloak,
-						ProvisionClient: boolPtr(false),
+						ProvisionClient: ptr.To(false),
 					},
 				},
 			},
@@ -806,8 +799,8 @@ func TestReconcileAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:          true,
 						Provider:         constants.ProviderKeycloak,
-						ProvisionClient:  boolPtr(false),
-						EnforceAtGateway: boolPtr(false),
+						ProvisionClient:  ptr.To(false),
+						EnforceAtGateway: ptr.To(false),
 					},
 				},
 			},
@@ -839,8 +832,8 @@ func TestReconcileAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:          true,
 						Provider:         constants.ProviderKeycloak,
-						ProvisionClient:  boolPtr(false),
-						EnforceAtGateway: boolPtr(false),
+						ProvisionClient:  ptr.To(false),
+						EnforceAtGateway: ptr.To(false),
 					},
 				},
 			},
@@ -880,7 +873,7 @@ func TestReconcileAuth(t *testing.T) {
 						Auth: &appsv1.AuthConfig{
 							Enabled:         true,
 							Provider:        constants.ProviderKeycloak,
-							ProvisionClient: boolPtr(true),
+							ProvisionClient: ptr.To(true),
 						},
 					},
 				}
@@ -927,7 +920,7 @@ func TestReconcileAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:         true,
 						Provider:        constants.ProviderKeycloak,
-						ProvisionClient: boolPtr(true),
+						ProvisionClient: ptr.To(true),
 					},
 				},
 				Status: appsv1.NebariAppStatus{
@@ -968,7 +961,7 @@ func TestReconcileAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:         true,
 						Provider:        constants.ProviderKeycloak,
-						ProvisionClient: boolPtr(true),
+						ProvisionClient: ptr.To(true),
 					},
 				},
 			},
@@ -1001,7 +994,7 @@ func TestReconcileAuth(t *testing.T) {
 						Auth: &appsv1.AuthConfig{
 							Enabled:         true,
 							Provider:        constants.ProviderKeycloak,
-							ProvisionClient: boolPtr(true),
+							ProvisionClient: ptr.To(true),
 						},
 					},
 				}
@@ -1154,7 +1147,7 @@ func TestCleanupAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:         true,
 						Provider:        constants.ProviderKeycloak,
-						ProvisionClient: boolPtr(true),
+						ProvisionClient: ptr.To(true),
 					},
 				},
 			},
@@ -1175,7 +1168,7 @@ func TestCleanupAuth(t *testing.T) {
 					Auth: &appsv1.AuthConfig{
 						Enabled:         true,
 						Provider:        constants.ProviderKeycloak,
-						ProvisionClient: boolPtr(true),
+						ProvisionClient: ptr.To(true),
 					},
 				},
 			},
@@ -1380,7 +1373,7 @@ func TestReconcileAuth_SpecChangeCycle(t *testing.T) {
 			initial: appsv1.AuthConfig{
 				Enabled:         true,
 				Provider:        constants.ProviderKeycloak,
-				ProvisionClient: boolPtr(true),
+				ProvisionClient: ptr.To(true),
 				RedirectURI:     "/oauth2/callback",
 			},
 			mutate: func(a *appsv1.AuthConfig) { a.RedirectURI = "/auth/callback" },
@@ -1390,7 +1383,7 @@ func TestReconcileAuth_SpecChangeCycle(t *testing.T) {
 			initial: appsv1.AuthConfig{
 				Enabled:         true,
 				Provider:        constants.ProviderKeycloak,
-				ProvisionClient: boolPtr(true),
+				ProvisionClient: ptr.To(true),
 				Groups:          []string{"admins"},
 			},
 			mutate: func(a *appsv1.AuthConfig) {
@@ -1402,7 +1395,7 @@ func TestReconcileAuth_SpecChangeCycle(t *testing.T) {
 			initial: appsv1.AuthConfig{
 				Enabled:         true,
 				Provider:        constants.ProviderKeycloak,
-				ProvisionClient: boolPtr(true),
+				ProvisionClient: ptr.To(true),
 				Scopes:          []string{"openid", "profile"},
 			},
 			mutate: func(a *appsv1.AuthConfig) {
@@ -1414,7 +1407,7 @@ func TestReconcileAuth_SpecChangeCycle(t *testing.T) {
 			initial: appsv1.AuthConfig{
 				Enabled:         true,
 				Provider:        constants.ProviderKeycloak,
-				ProvisionClient: boolPtr(true),
+				ProvisionClient: ptr.To(true),
 				KeycloakConfig: &appsv1.KeycloakClientConfig{
 					Groups: []appsv1.KeycloakGroup{{Name: "admins", Members: []string{"alice"}}},
 				},

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -66,14 +66,15 @@ func verifyOptionalEndpoint(t *testing.T, name string, actual, expected *string)
 
 // mockProvider implements OIDCProvider for testing
 type mockProvider struct {
-	issuerURL            string
-	endpointOverrides    providers.OIDCEndpointOverrides
-	clientID             string
-	supportsProvisioning bool
-	provisionError       error
-	deleteError          error
-	issuerError          error
-	provisionCount       int // tracks how many times ProvisionClient was called
+	issuerURL              string
+	endpointOverrides      providers.OIDCEndpointOverrides
+	endpointOverridesError error
+	clientID               string
+	supportsProvisioning   bool
+	provisionError         error
+	deleteError            error
+	issuerError            error
+	provisionCount         int // tracks how many times ProvisionClient was called
 }
 
 func (m *mockProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {
@@ -84,7 +85,7 @@ func (m *mockProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.Nebar
 }
 
 func (m *mockProvider) GetEndpointOverrides(_ context.Context, _ *appsv1.NebariApp) (providers.OIDCEndpointOverrides, error) {
-	return m.endpointOverrides, nil
+	return m.endpointOverrides, m.endpointOverridesError
 }
 
 func (m *mockProvider) GetExternalIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {
@@ -550,6 +551,28 @@ func TestBuildSecurityPolicySpec(t *testing.T) {
 				issuerURL:   "",
 				clientID:    "test-client",
 				issuerError: errors.New("failed to get issuer URL"),
+			},
+			expectError: true,
+		},
+		{
+			name: "Endpoint overrides error",
+			nebariApp: &appsv1.NebariApp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: appsv1.NebariAppSpec{
+					Hostname: "test.example.com",
+					Auth: &appsv1.AuthConfig{
+						Enabled:  true,
+						Provider: constants.ProviderKeycloak,
+					},
+				},
+			},
+			provider: &mockProvider{
+				issuerURL:              "https://keycloak.example.com/realms/test",
+				clientID:               "test-client",
+				endpointOverridesError: errors.New("failed to resolve endpoints"),
 			},
 			expectError: true,
 		},

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -35,28 +35,39 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// boolPtr returns a pointer to a bool value
-// verifyTokenEndpoint checks that the SecurityPolicy's token endpoint matches expectations.
-func verifyTokenEndpoint(t *testing.T, sp *egv1alpha1.SecurityPolicy, expected string) {
-	t.Helper()
-	actual := sp.Spec.OIDC.Provider.TokenEndpoint
-	if expected != "" {
-		if actual == nil || *actual != expected {
-			t.Errorf("expected token endpoint %q, got %v", expected, actual)
-		}
-	} else if actual != nil {
-		t.Errorf("expected no explicit token endpoint, got %q", *actual)
-	}
-}
-
+// boolPtr returns a pointer to a bool value.
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+// verifyEndpointOverrides checks that the SecurityPolicy's endpoint overrides match expectations.
+func verifyEndpointOverrides(t *testing.T, sp *egv1alpha1.SecurityPolicy, expected providers.OIDCEndpointOverrides) {
+	t.Helper()
+	p := sp.Spec.OIDC.Provider
+	verifyOptionalEndpoint(t, "token", p.TokenEndpoint, expected.Token)
+	verifyOptionalEndpoint(t, "authorization", p.AuthorizationEndpoint, expected.Authorization)
+	verifyOptionalEndpoint(t, "endSession", p.EndSessionEndpoint, expected.EndSession)
+}
+
+func verifyOptionalEndpoint(t *testing.T, name string, actual, expected *string) {
+	t.Helper()
+	if expected != nil {
+		if actual == nil || *actual != *expected {
+			t.Errorf("expected %s endpoint %q, got %v", name, *expected, actual)
+		}
+	} else if actual != nil {
+		t.Errorf("expected no explicit %s endpoint, got %q", name, *actual)
+	}
 }
 
 // mockProvider implements OIDCProvider for testing
 type mockProvider struct {
 	issuerURL            string
-	tokenEndpoint        string
+	endpointOverrides    providers.OIDCEndpointOverrides
 	clientID             string
 	supportsProvisioning bool
 	provisionError       error
@@ -72,8 +83,8 @@ func (m *mockProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.Nebar
 	return m.issuerURL, nil
 }
 
-func (m *mockProvider) GetTokenEndpoint(ctx context.Context, nebariApp *appsv1.NebariApp) string {
-	return m.tokenEndpoint
+func (m *mockProvider) GetEndpointOverrides(_ context.Context, _ *appsv1.NebariApp) (providers.OIDCEndpointOverrides, error) {
+	return m.endpointOverrides, nil
 }
 
 func (m *mockProvider) GetExternalIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {
@@ -586,6 +597,7 @@ func TestReconcileAuth(t *testing.T) {
 		existingSecret         *corev1.Secret
 		existingSecurityPolicy *egv1alpha1.SecurityPolicy
 		provider               *mockProvider
+		expectedOverrides      providers.OIDCEndpointOverrides
 		expectError            bool
 		// validate runs additional assertions after reconciliation (optional)
 		validate func(*testing.T, *mockProvider, *appsv1.NebariApp)
@@ -661,7 +673,7 @@ func TestReconcileAuth(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "Auth enabled with explicit token endpoint",
+			name: "Auth enabled with explicit endpoint overrides",
 			nebariApp: &appsv1.NebariApp{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-app",
@@ -686,15 +698,24 @@ func TestReconcileAuth(t *testing.T) {
 				},
 			},
 			provider: &mockProvider{
-				issuerURL:            "https://keycloak.example.com/realms/test",
-				tokenEndpoint:        "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token",
+				issuerURL: "https://keycloak.example.com/realms/test",
+				endpointOverrides: providers.OIDCEndpointOverrides{
+					Token:         strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token"),
+					Authorization: strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/auth"),
+					EndSession:    strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/logout"),
+				},
 				clientID:             "test-client",
 				supportsProvisioning: true,
+			},
+			expectedOverrides: providers.OIDCEndpointOverrides{
+				Token:         strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token"),
+				Authorization: strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/auth"),
+				EndSession:    strPtr("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/logout"),
 			},
 			expectError: false,
 		},
 		{
-			name: "Auth enabled without explicit token endpoint (discovery)",
+			name: "Auth enabled without endpoint overrides (discovery)",
 			nebariApp: &appsv1.NebariApp{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-app",
@@ -720,11 +741,11 @@ func TestReconcileAuth(t *testing.T) {
 			},
 			provider: &mockProvider{
 				issuerURL:            "https://keycloak.example.com/realms/test",
-				tokenEndpoint:        "", // empty means use discovery
 				clientID:             "test-client",
 				supportsProvisioning: true,
 			},
-			expectError: false,
+			expectedOverrides: providers.OIDCEndpointOverrides{},
+			expectError:       false,
 		},
 		{
 			name: "Auth enabled but secret missing",
@@ -1057,7 +1078,7 @@ func TestReconcileAuth(t *testing.T) {
 					if err != nil {
 						t.Errorf("expected SecurityPolicy to be created, got error: %v", err)
 					} else if securityPolicy.Spec.OIDC != nil {
-						verifyTokenEndpoint(t, securityPolicy, tt.provider.GetTokenEndpoint(context.Background(), tt.nebariApp))
+						verifyEndpointOverrides(t, securityPolicy, tt.expectedOverrides)
 					}
 				} else {
 					if err == nil {

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -43,6 +43,7 @@ func boolPtr(b bool) *bool {
 // mockProvider implements OIDCProvider for testing
 type mockProvider struct {
 	issuerURL            string
+	tokenEndpoint        string
 	clientID             string
 	supportsProvisioning bool
 	provisionError       error
@@ -56,6 +57,10 @@ func (m *mockProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.Nebar
 		return "", m.issuerError
 	}
 	return m.issuerURL, nil
+}
+
+func (m *mockProvider) GetTokenEndpoint(ctx context.Context, nebariApp *appsv1.NebariApp) string {
+	return m.tokenEndpoint
 }
 
 func (m *mockProvider) GetExternalIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {
@@ -643,6 +648,72 @@ func TestReconcileAuth(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "Auth enabled with explicit token endpoint",
+			nebariApp: &appsv1.NebariApp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: appsv1.NebariAppSpec{
+					Hostname: "test.example.com",
+					Auth: &appsv1.AuthConfig{
+						Enabled:         true,
+						Provider:        constants.ProviderKeycloak,
+						ProvisionClient: boolPtr(false),
+					},
+				},
+			},
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app-oidc-client",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					constants.ClientSecretKey: []byte("test-secret"),
+				},
+			},
+			provider: &mockProvider{
+				issuerURL:            "https://keycloak.example.com/realms/test",
+				tokenEndpoint:        "http://keycloak.keycloak.svc.cluster.local:8080/realms/test/protocol/openid-connect/token",
+				clientID:             "test-client",
+				supportsProvisioning: true,
+			},
+			expectError: false,
+		},
+		{
+			name: "Auth enabled without explicit token endpoint (discovery)",
+			nebariApp: &appsv1.NebariApp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: appsv1.NebariAppSpec{
+					Hostname: "test.example.com",
+					Auth: &appsv1.AuthConfig{
+						Enabled:         true,
+						Provider:        constants.ProviderKeycloak,
+						ProvisionClient: boolPtr(false),
+					},
+				},
+			},
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app-oidc-client",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					constants.ClientSecretKey: []byte("test-secret"),
+				},
+			},
+			provider: &mockProvider{
+				issuerURL:            "https://keycloak.example.com/realms/test",
+				tokenEndpoint:        "", // empty means use discovery
+				clientID:             "test-client",
+				supportsProvisioning: true,
+			},
+			expectError: false,
+		},
+		{
 			name: "Auth enabled but secret missing",
 			nebariApp: &appsv1.NebariApp{
 				ObjectMeta: metav1.ObjectMeta{
@@ -972,6 +1043,20 @@ func TestReconcileAuth(t *testing.T) {
 				if shouldEnforceAtGateway(tt.nebariApp.Spec.Auth) {
 					if err != nil {
 						t.Errorf("expected SecurityPolicy to be created, got error: %v", err)
+					} else if securityPolicy.Spec.OIDC != nil {
+						// Verify token endpoint matches provider's GetTokenEndpoint
+						tokenEndpoint := tt.provider.GetTokenEndpoint(context.Background(), tt.nebariApp)
+						if tokenEndpoint != "" {
+							if securityPolicy.Spec.OIDC.Provider.TokenEndpoint == nil {
+								t.Error("expected SecurityPolicy to have explicit token endpoint set")
+							} else if *securityPolicy.Spec.OIDC.Provider.TokenEndpoint != tokenEndpoint {
+								t.Errorf("expected token endpoint %q, got %q", tokenEndpoint, *securityPolicy.Spec.OIDC.Provider.TokenEndpoint)
+							}
+						} else {
+							if securityPolicy.Spec.OIDC.Provider.TokenEndpoint != nil {
+								t.Errorf("expected no explicit token endpoint, got %q", *securityPolicy.Spec.OIDC.Provider.TokenEndpoint)
+							}
+						}
 					}
 				} else {
 					if err == nil {

--- a/internal/controller/utils/ptr/ptr.go
+++ b/internal/controller/utils/ptr/ptr.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026, OpenTeams.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ptr
+
+// To returns a pointer to the given value.
+func To[T any](v T) *T {
+	return &v
+}

--- a/internal/controller/utils/ptr/ptr_test.go
+++ b/internal/controller/utils/ptr/ptr_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026, OpenTeams.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ptr
+
+import "testing"
+
+func TestTo(t *testing.T) {
+	s := To("hello")
+	if s == nil || *s != "hello" {
+		t.Errorf("expected pointer to %q, got %v", "hello", s)
+	}
+
+	n := To(42)
+	if n == nil || *n != 42 {
+		t.Errorf("expected pointer to %d, got %v", 42, n)
+	}
+
+	b := To(true)
+	if b == nil || *b != true {
+		t.Errorf("expected pointer to %v, got %v", true, b)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix OAuth flow failure (`CERTIFICATE_VERIFY_FAILED`) when Envoy exchanges the auth code for a token with Keycloak
- Add `GetTokenEndpoint` to the `OIDCProvider` interface so providers can specify an explicit token endpoint
- Keycloak provider returns the internal HTTP token endpoint, generic OIDC provider defers to discovery

## Problem

When a NebariApp has OIDC authentication enabled, the SecurityPolicy's issuer is set to the **internal** Keycloak HTTP URL:
```
http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari
```

Envoy fetches the OIDC discovery document from this URL successfully. However, Keycloak has an external frontend URL configured, so the discovery document returns the **external** HTTPS URL for the token endpoint:
```
https://keycloak.nebari.local/auth/realms/nebari/protocol/openid-connect/token
```

When the user completes Keycloak login and gets redirected back with an auth code, Envoy tries to exchange the code for tokens by calling this external HTTPS endpoint. This fails because:
- In local/dev environments: the TLS certificate is self-signed and not trusted by Envoy
- Error: `CERTIFICATE_VERIFY_FAILED` → 401 "OAuth flow failed"

The browser redirect to Keycloak login works fine (that's a browser-side redirect using the external URL), but the server-to-server token exchange fails.

## Solution

Explicitly set the `tokenEndpoint` field on the SecurityPolicy's OIDC provider configuration. This tells Envoy to use the specified URL for token exchange instead of the one discovered from the OIDC configuration document.

For Keycloak, the token endpoint is set to:
```
http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/token
```

This keeps the server-to-server token exchange inside the cluster over HTTP, avoiding TLS verification entirely.

### Why this also benefits cloud deployments

Even when TLS certificates are valid (e.g., Let's Encrypt on cloud), using the internal endpoint is better because:
- Token exchange stays within the cluster (lower latency)
- No hairpin routing through the external load balancer
- No dependency on external DNS resolution for server-to-server calls

### Changes

| File | Change |
|------|--------|
| `providers/provider.go` | Add `GetTokenEndpoint` to `OIDCProvider` interface |
| `providers/keycloak.go` | Implement `GetTokenEndpoint` returning internal HTTP URL |
| `providers/generic_oidc.go` | Implement `GetTokenEndpoint` returning empty (use discovery) |
| `auth/reconciler.go` | Set `TokenEndpoint` on SecurityPolicy when provider returns one |
| `auth/reconciler_test.go` | Add test cases for both explicit and discovery token endpoints |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/reconcilers/auth/...` passes (all existing + 2 new tests)
- [ ] Deploy operator to local kind cluster and verify OIDC login flow completes successfully
- [ ] Verify SecurityPolicy shows `tokenEndpoint` set to internal URL
- [ ] Verify generic-oidc provider does not set tokenEndpoint (falls back to discovery)