### PR TITLE
feat: add custom port option for health checks

### DIFF
--- a/api/v1/nebariapp_types.go
+++ b/api/v1/nebariapp_types.go
@@ -370,6 +370,13 @@ type HealthCheckConfig struct {
 	// +optional
 	Path string `json:"path,omitempty"`
 
+	// Port is the port number to use for health checks.
+	// If not specified, defaults to the service port defined in spec.service.port.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	Port *int32 `json:"port,omitempty"`
+
 	// IntervalSeconds is how often to perform health checks (in seconds).
 	// +kubebuilder:default=30
 	// +kubebuilder:validation:Minimum=10

--- a/config/crd/bases/reconcilers.nebari.dev_nebariapps.yaml
+++ b/config/crd/bases/reconcilers.nebari.dev_nebariapps.yaml
@@ -291,6 +291,14 @@ spec:
                           Path is the HTTP path to check for health status.
                           Common paths: /health, /healthz, /api/health
                         type: string
+                      port:
+                        description: |-
+                          Port is the port number to use for health checks.
+                          If not specified, defaults to the service port defined in spec.service.port.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
                       timeoutSeconds:
                         default: 5
                         description: TimeoutSeconds is the request timeout for health


### PR DESCRIPTION
## Description

This PR adds an optional `port` field to `HealthCheckConfig`, allowing users to specify a custom port for health checks that differs from the main service port.

## Changes

- Added `Port *int32` field to `HealthCheckConfig` in API types
- Field is optional with validation (1-65535 range)
- Defaults to service port when not specified
- Regenerated CRDs with the new field

## Use Case

This is useful when applications expose health endpoints on a separate port (e.g., admin/metrics port) while the main service runs on another port. For example:
- Main service on port 8080
- Health/metrics endpoint on port 9090

## Example

```yaml
spec:
  service:
    name: my-app
    port: 8080
  healthCheck:
    enabled: true
    path: /healthz
    port: 9090  # Health check on different port
```

## Testing

- [x] CRDs regenerated successfully
- [x] Validation constraints applied (1-65535)
- [x] Optional field with backward compatibility