### PR TITLE
Parallelize e2e tests with shared operator deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,16 +81,16 @@ test-unit-html: test-unit ## Generate HTML coverage report for unit tests.
 	@xdg-open unit-coverage.html 2>/dev/null || open unit-coverage.html 2>/dev/null || echo "Open unit-coverage.html in your browser"
 
 .PHONY: test-e2e
-test-e2e: manifests generate fmt vet ## Run all e2e tests.
-	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMG=$(IMG) go test ./test/e2e -v -ginkgo.v -tags=e2e -timeout=30m
+test-e2e: manifests generate fmt vet ginkgo ## Run all e2e tests (parallel by default).
+	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMG=$(IMG) "$(GINKGO)" -v --procs=4 --tags=e2e --timeout=30m ./test/e2e/
 
-.PHONY: test-e2e-parallel
-test-e2e-parallel: manifests generate fmt vet ## Run e2e tests in parallel (faster).
-	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) go test ./test/e2e -v -ginkgo.v -ginkgo.procs=4 -tags=e2e -timeout=30m
+.PHONY: test-e2e-serial
+test-e2e-serial: manifests generate fmt vet ginkgo ## Run e2e tests serially (for debugging).
+	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMG=$(IMG) "$(GINKGO)" -v --tags=e2e --timeout=30m ./test/e2e/
 
 .PHONY: test-e2e-smoke
-test-e2e-smoke: manifests generate fmt vet ## Run quick smoke tests only.
-	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) go test ./test/e2e -v -ginkgo.v -ginkgo.focus="should reconcile a NebariApp" -tags=e2e -timeout=10m
+test-e2e-smoke: manifests generate fmt vet ginkgo ## Run quick smoke tests only.
+	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMG=$(IMG) "$(GINKGO)" -v --tags=e2e --timeout=10m --focus="should reconcile a NebariApp" ./test/e2e/
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
@@ -279,6 +279,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+GINKGO = $(LOCALBIN)/ginkgo
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
@@ -295,6 +296,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
+GINKGO_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2 2>/dev/null)
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -322,6 +324,11 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: ginkgo
+ginkgo: $(GINKGO) ## Download ginkgo CLI locally if necessary.
+$(GINKGO): $(LOCALBIN)
+	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo,$(GINKGO_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"time"
@@ -36,105 +35,12 @@ var _ = Describe("NebariApp Authentication", Ordered, func() {
 	const keycloakNamespace = "keycloak"
 
 	BeforeAll(func() {
-		var cmd *exec.Cmd
-		var err error
-
-		By("installing NebariApp CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
-		By("cleaning up any existing auth test resources")
-		cmd = exec.Command("kubectl", "delete", "namespace", testNamespace, "--ignore-not-found", "--timeout=60s")
-		_, _ = utils.Run(cmd)
-
-		By("waiting for namespace to be fully deleted")
-		Eventually(func() error {
-			cmd = exec.Command("kubectl", "get", "namespace", testNamespace)
-			_, err := utils.Run(cmd)
-			return err
-		}, 2*time.Minute, time.Second).Should(HaveOccurred())
-			By("undeploying any existing controller-manager")
-			_, _ = utils.Run(exec.Command("make", "undeploy"))
-		By("waiting for operator namespace to be fully terminated from previous runs")
-		Eventually(func() error {
-			cmd = exec.Command("kubectl", "get", "namespace", "nebari-operator-system")
-			_, err := utils.Run(cmd)
-			return err
-		}, VeryLongTimeout, time.Second).Should(HaveOccurred(),
-			"nebari-operator-system should be absent before deploying")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-
-		By("waiting for controller-manager to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "nebari-operator-controller-manager",
-				"-n", "nebari-operator-system", "-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, 2*time.Minute, time.Second).Should(Succeed())
-
-		By("verifying operator can load Keycloak configuration")
-		// Check that the operator pod logged successful config loading
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "logs", "-n", "nebari-operator-system",
-				"-l", "control-plane=controller-manager",
-				"--tail=100")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			// Should not have config errors
-			g.Expect(output).NotTo(ContainSubstring("failed to load config"))
-			g.Expect(output).NotTo(ContainSubstring("config error"))
-		}, 1*time.Minute, 5*time.Second).Should(Succeed())
-
-		By("creating test namespace")
-		cmd = exec.Command("kubectl", "create", "namespace", testNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling namespace for Operator management")
-		cmd = exec.Command("kubectl", "label", "namespace", testNamespace, "nebari.dev/managed=true")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace")
-
-		By("creating a test application deployment")
-		var appYAML string
-		appYAML, err = utils.LoadTestDataFile("test-app.yaml", map[string]string{
-			"NAMESPACE_PLACEHOLDER": testNamespace,
-		})
-		Expect(err).NotTo(HaveOccurred(), "Failed to load test-app.yaml")
-
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
-		cmd.Stdin = strings.NewReader(appYAML)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create test application")
-
-		By("waiting for test application to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "test-app", "-n", testNamespace,
-				"-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, 2*time.Minute, time.Second).Should(Succeed())
+		SetupTestNamespace(testNamespace)
+		DeployTestApp(testNamespace)
 	})
 
 	AfterAll(func() {
-		By("cleaning up auth test resources")
-		cmd := exec.Command("kubectl", "delete", "namespace", testNamespace, "--ignore-not-found")
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
+		CleanupTestNamespace(testNamespace)
 	})
 
 	Context("Operator Configuration", func() {

--- a/test/e2e/conditions_test.go
+++ b/test/e2e/conditions_test.go
@@ -37,46 +37,7 @@ var _ = Describe("NebariApp Status Conditions", Ordered, func() {
 	const testNamespace = "e2e-test-conditions"
 
 	BeforeAll(func() {
-		var cmd *exec.Cmd
-		var err error
-
-		By("installing NebariApp CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
-		By("creating test namespace")
-		cmd = exec.Command("kubectl", "create", "namespace", testNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling namespace for Operator management")
-		cmd = exec.Command("kubectl", "label", "namespace", testNamespace, "nebari.dev/managed=true")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace")
-			By("undeploying any existing controller-manager")
-			_, _ = utils.Run(exec.Command("make", "undeploy"))
-		By("waiting for operator namespace to be fully terminated from previous runs")
-		Eventually(func() error {
-			cmd = exec.Command("kubectl", "get", "namespace", "nebari-operator-system")
-			_, err := utils.Run(cmd)
-			return err
-		}, VeryLongTimeout, time.Second).Should(HaveOccurred(),
-			"nebari-operator-system should be absent before deploying")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-
-		By("waiting for controller-manager to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "nebari-operator-controller-manager",
-				"-n", "nebari-operator-system", "-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, MediumTimeout, PollInterval).Should(Succeed())
+		SetupTestNamespace(testNamespace)
 
 		By("creating test service")
 		serviceYAML := fmt.Sprintf(`
@@ -92,24 +53,14 @@ spec:
   - port: 8080
     targetPort: 8080
 `, testNamespace)
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
 		cmd.Stdin = strings.NewReader(serviceYAML)
-		_, err = utils.Run(cmd)
+		_, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func() {
-		By("cleaning up test resources")
-		cmd := exec.Command("kubectl", "delete", "namespace", testNamespace, "--ignore-not-found")
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
+		CleanupTestNamespace(testNamespace)
 	})
 
 	Context("Condition State Machine", func() {

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -87,16 +87,10 @@ var _ = Describe("HTTPRoute Connectivity", Ordered, func() {
 
 	BeforeAll(func() {
 		var err error
-
 		testNamespace = "e2e-test-connectivity"
 
-		By("installing NebariApp CRDs")
-		cmd := exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
 		By("checking if Gateway exists")
-		cmd = exec.Command("kubectl", "get", "gateway", "nebari-gateway", "-n", "envoy-gateway-system")
+		cmd := exec.Command("kubectl", "get", "gateway", "nebari-gateway", "-n", "envoy-gateway-system")
 		_, err = utils.Run(cmd)
 		if err != nil {
 			Skip("Gateway 'nebari-gateway' not found - run 'make setup' in dev/ first")
@@ -114,80 +108,14 @@ var _ = Describe("HTTPRoute Connectivity", Ordered, func() {
 			gatewayIP = strings.TrimSpace(output)
 			return gatewayIP
 		}, 3*time.Minute, 5*time.Second).ShouldNot(BeEmpty(), "Gateway LoadBalancer IP not assigned")
-
 		By(fmt.Sprintf("Gateway IP: %s", gatewayIP))
 
-		By("creating test namespace")
-		cmd = exec.Command("kubectl", "create", "namespace", testNamespace, "--dry-run=client", "-o", "yaml")
-		output, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred())
-
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
-		cmd.Stdin = strings.NewReader(output)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling namespace for Operator management")
-		cmd = exec.Command("kubectl", "label", "namespace", testNamespace, "nebari.dev/managed=true", "--overwrite")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace")
-			By("undeploying any existing controller-manager")
-			_, _ = utils.Run(exec.Command("make", "undeploy"))
-		By("waiting for operator namespace to be fully terminated from previous runs")
-		Eventually(func() error {
-			cmd = exec.Command("kubectl", "get", "namespace", "nebari-operator-system")
-			_, err = utils.Run(cmd)
-			return err
-		}, VeryLongTimeout, time.Second).Should(HaveOccurred(),
-			"nebari-operator-system should be absent before deploying")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-
-		By("waiting for controller-manager to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "nebari-operator-controller-manager",
-				"-n", "nebari-operator-system", "-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, 2*time.Minute, time.Second).Should(Succeed())
-
-		By("creating a test application deployment")
-		appYAML, err := utils.LoadTestDataFile("test-app.yaml", map[string]string{
-			"NAMESPACE_PLACEHOLDER": testNamespace,
-		})
-		Expect(err).NotTo(HaveOccurred(), "Failed to load test-app.yaml")
-
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
-		cmd.Stdin = strings.NewReader(appYAML)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create test application")
-
-		By("waiting for test application to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "test-app", "-n", testNamespace,
-				"-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, 2*time.Minute, time.Second).Should(Succeed())
+		SetupTestNamespace(testNamespace)
+		DeployTestApp(testNamespace)
 	})
 
 	AfterAll(func() {
-		By("cleaning up test resources")
-		cmd := exec.Command("kubectl", "delete", "namespace", testNamespace, "--ignore-not-found", "--timeout=60s")
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
+		CleanupTestNamespace(testNamespace)
 	})
 
 	Context("HTTP Connectivity", func() {
@@ -386,7 +314,7 @@ spec:
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("True"))
-			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
 			By("testing HTTPS connectivity via Gateway IP")
 			// Try direct access first, fall back to port-forward if needed

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -75,10 +76,8 @@ func TestE2E(t *testing.T) {
 	RunSpecs(t, "e2e suite")
 }
 
-var _ = BeforeSuite(func() {
-	if skipSetup {
-		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping all setup, using existing cluster and infrastructure\n")
-	} else {
+var _ = SynchronizedBeforeSuite(func() []byte {
+	if !skipSetup {
 		// Set cluster name for Kind utilities
 		clusterName := os.Getenv("CLUSTER_NAME")
 		if clusterName == "" {
@@ -128,8 +127,58 @@ var _ = BeforeSuite(func() {
 		} else {
 			_, _ = fmt.Fprintf(GinkgoWriter, "Skipping docker build, assuming image is already built and loaded\n")
 		}
+
+		// Install CRDs
+		By("installing CRDs")
+		cmd := exec.Command("make", "install")
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+		// Clean up any existing deployment
+		By("undeploying any existing operator")
+		cmd = exec.Command("make", "undeploy")
+		_, _ = utils.Run(cmd) // ignore error if nothing is deployed
+
+		By("waiting for operator namespace to be fully removed")
+		Eventually(func() error {
+			cmd := exec.Command("kubectl", "get", "namespace", "nebari-operator-system")
+			_, err := utils.Run(cmd)
+			return err
+		}, 5*time.Minute, time.Second).Should(HaveOccurred(), "Timed out waiting for nebari-operator-system namespace to be removed")
+
+		// Deploy the operator
+		By("deploying the operator")
+		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+		_, err = utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to deploy the operator")
+
+		By("waiting for controller-manager deployment to be available")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "deployment", "nebari-operator-controller-manager",
+				"-n", "nebari-operator-system",
+				"-o", "jsonpath={.status.availableReplicas}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("1"))
+		}, 2*time.Minute, time.Second).Should(Succeed(), "Controller manager deployment did not become available")
+
+		By("verifying operator logs for configuration errors")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "logs",
+				"deployment/nebari-operator-controller-manager",
+				"-n", "nebari-operator-system",
+				"--tail=100")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).NotTo(ContainSubstring("failed to load config"))
+			g.Expect(output).NotTo(ContainSubstring("config error"))
+		}, 1*time.Minute, time.Second).Should(Succeed(), "Operator logs contain configuration errors")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping all setup, using existing cluster and infrastructure\n")
 	}
 
+	return nil
+}, func(_ []byte) {
 	By("setting up the k8s client")
 	scheme := runtime.NewScheme()
 	ExpectWithOffset(1, clientgoscheme.AddToScheme(scheme)).To(Succeed())
@@ -140,9 +189,23 @@ var _ = BeforeSuite(func() {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create k8s client")
 })
 
-var _ = AfterSuite(func() {
+var _ = SynchronizedAfterSuite(func() {
+	// Nothing to do per-process
+}, func() {
 	if skipSetup {
 		return
+	}
+
+	By("undeploying the operator")
+	cmd := exec.Command("make", "undeploy")
+	if _, err := utils.Run(cmd); err != nil {
+		warnError(err)
+	}
+
+	By("uninstalling CRDs")
+	cmd = exec.Command("make", "uninstall")
+	if _, err := utils.Run(cmd); err != nil {
+		warnError(err)
 	}
 
 	// Teardown via dev scripts if we set things up

--- a/test/e2e/e2e_utils.go
+++ b/test/e2e/e2e_utils.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -100,4 +102,62 @@ type tokenRequest struct {
 	Status struct {
 		Token string `json:"token"`
 	} `json:"status"`
+}
+
+// SetupTestNamespace creates a namespace with the nebari.dev/managed=true label.
+// It cleans up any existing namespace with the same name first.
+func SetupTestNamespace(namespaceName string) {
+	By(fmt.Sprintf("cleaning up any existing %s namespace", namespaceName))
+	cmd := exec.Command("kubectl", "delete", "namespace", namespaceName, "--ignore-not-found", "--timeout=60s")
+	_, _ = utils.Run(cmd)
+
+	By(fmt.Sprintf("waiting for namespace %s to be fully deleted", namespaceName))
+	Eventually(func() error {
+		cmd := exec.Command("kubectl", "get", "namespace", namespaceName)
+		_, err := utils.Run(cmd)
+		return err
+	}, 2*time.Minute, time.Second).Should(HaveOccurred())
+
+	By(fmt.Sprintf("creating test namespace %s", namespaceName))
+	cmd = exec.Command("kubectl", "create", "namespace", namespaceName)
+	_, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create namespace")
+
+	By(fmt.Sprintf("labeling namespace %s for Operator management", namespaceName))
+	cmd = exec.Command("kubectl", "label", "namespace", namespaceName, "nebari.dev/managed=true")
+	_, err = utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to label namespace")
+}
+
+// DeployTestApp deploys the standard test-app Deployment+Service into the given namespace
+// and waits for it to be ready.
+func DeployTestApp(namespaceName string) {
+	By("creating a test application deployment")
+	appYAML, err := utils.LoadTestDataFile("test-app.yaml", map[string]string{
+		"NAMESPACE_PLACEHOLDER": namespaceName,
+	})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load test-app.yaml")
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(appYAML)
+	_, err = utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create test application")
+
+	By("waiting for test application to be ready")
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "get", "deployment", "test-app", "-n", namespaceName,
+			"-o", "jsonpath={.status.availableReplicas}")
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(output).To(Equal("1"))
+	}, 2*time.Minute, time.Second).Should(Succeed(), func() string {
+		return DeploymentDiagnostics(namespaceName, "test-app")
+	})
+}
+
+// CleanupTestNamespace deletes the test namespace.
+func CleanupTestNamespace(namespaceName string) {
+	By(fmt.Sprintf("cleaning up namespace %s", namespaceName))
+	cmd := exec.Command("kubectl", "delete", "namespace", namespaceName, "--ignore-not-found", "--timeout=60s")
+	_, _ = utils.Run(cmd)
 }

--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -22,7 +22,6 @@ package e2e
 import (
 	"fmt"
 	"os/exec"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,67 +33,36 @@ import (
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
 
-	// Before running the tests, set up the environment by creating the namespace,
-	// enforce the restricted security policy to the namespace, installing CRDs,
-	// and deploying the controller.
 	BeforeAll(func() {
-		By("undeploying any existing controller-manager")
-		_, _ = utils.Run(exec.Command("make", "undeploy"))
+		By("verifying controller-manager is running (deployed in BeforeSuite)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+				"-o", "go-template={{ range .items }}"+
+					"{{ if not .metadata.deletionTimestamp }}"+
+					"{{ .metadata.name }}"+
+					"{{ \"\\n\" }}{{ end }}{{ end }}",
+				"-n", namespace)
+			podOutput, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			podNames := utils.GetNonEmptyLines(podOutput)
+			g.Expect(podNames).To(HaveLen(1))
+			controllerPodName = podNames[0]
 
-		By("waiting for operator namespace to be fully terminated from previous runs")
-		// Ginkgo randomizes suite execution order, so a prior suite may have left
-		// nebari-operator-system in a terminating state. Wait for it to be gone.
-		Eventually(func() error {
-			cmd := exec.Command("kubectl", "get", "namespace", "nebari-operator-system")
-			_, err := utils.Run(cmd)
-			return err
-		}, VeryLongTimeout, time.Second).Should(HaveOccurred(),
-			"nebari-operator-system should be absent before deploying")
-
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace, "--dry-run=client", "-o", "yaml")
-		output, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to generate namespace yaml")
-
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
-		cmd.Stdin = strings.NewReader(output)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling the namespace to enforce the restricted security policy")
-		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
-			"pod-security.kubernetes.io/enforce=restricted")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
-
-		By("installing CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+			cmd = exec.Command("kubectl", "get", "pods", controllerPodName,
+				"-o", "jsonpath={.status.phase}", "-n", namespace)
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Running"), "Controller pod not yet running")
+		}, 2*time.Minute, time.Second).Should(Succeed())
 	})
 
-	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
-	// and deleting the namespace.
 	AfterAll(func() {
 		By("cleaning up the curl pod for metrics")
-		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
+		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace, "--ignore-not-found")
 		_, _ = utils.Run(cmd)
 
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
-
-		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace)
+		By("cleaning up metrics ClusterRoleBinding")
+		cmd = exec.Command("kubectl", "delete", "clusterrolebinding", metricsRoleBindingName, "--ignore-not-found")
 		_, _ = utils.Run(cmd)
 	})
 

--- a/test/e2e/nebariapp_test.go
+++ b/test/e2e/nebariapp_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"time"
@@ -35,142 +34,25 @@ var _ = Describe("NebariApp Reconciliation", Ordered, func() {
 	var testNamespace string
 
 	BeforeAll(func() {
-		var cmd *exec.Cmd
-		var err error
-		var output string
-
-		// Check if Gateway API CRDs are installed
-		cmd = exec.Command("kubectl", "get", "crd", "gateways.gateway.networking.k8s.io")
-		_, err = utils.Run(cmd)
+		cmd := exec.Command("kubectl", "get", "crd", "gateways.gateway.networking.k8s.io")
+		_, err := utils.Run(cmd)
 		if err != nil {
 			Skip("Gateway API CRDs not installed - skipping NebariApp tests")
 		}
 
-		By("installing NebariApp CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
 		testNamespace = "e2e-test-app"
-
-		By("cleaning up any existing test resources")
-		cmd = exec.Command("kubectl", "get", "nebariapp", "-n", testNamespace, "-o", "name")
-		output, _ = utils.Run(cmd)
-		if output != "" {
-			cmd = exec.Command("kubectl", "delete", "nebariapp", "--all", "-n", testNamespace, "--timeout=60s")
-			_, _ = utils.Run(cmd)
-		}
-		cmd = exec.Command("kubectl", "delete", "namespace", testNamespace, "--ignore-not-found", "--timeout=60s")
-		_, _ = utils.Run(cmd)
-
-		By("waiting for namespace to be fully deleted")
-		Eventually(func() error {
-			cmd = exec.Command("kubectl", "get", "namespace", testNamespace)
-			_, err := utils.Run(cmd)
-			return err // Will return error when namespace doesn't exist
-		}, 2*time.Minute, time.Second).Should(HaveOccurred())
 
 		By("verifying Gateway exists")
 		cmd = exec.Command("kubectl", "get", "gateway", "nebari-gateway", "-n", "envoy-gateway-system")
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Gateway nebari-gateway must exist")
 
-		By("creating test namespace")
-		cmd = exec.Command("kubectl", "create", "namespace", testNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling namespace for Operator management")
-		cmd = exec.Command("kubectl", "label", "namespace", testNamespace, "nebari.dev/managed=true")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace")
-			By("undeploying any existing controller-manager")
-			_, _ = utils.Run(exec.Command("make", "undeploy"))
-		By("waiting for operator namespace to be fully terminated from previous runs")
-		Eventually(func() error {
-			cmd = exec.Command("kubectl", "get", "namespace", "nebari-operator-system")
-			_, err = utils.Run(cmd)
-			return err
-		}, VeryLongTimeout, time.Second).Should(HaveOccurred(),
-			"nebari-operator-system should be absent before deploying")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-
-		By("waiting for controller-manager to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "nebari-operator-controller-manager",
-				"-n", "nebari-operator-system", "-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, 2*time.Minute, time.Second).Should(Succeed())
-
-		By("creating a test application deployment")
-		var appYAML string
-		appYAML, err = utils.LoadTestDataFile("test-app.yaml", map[string]string{
-			"NAMESPACE_PLACEHOLDER": testNamespace,
-		})
-		Expect(err).NotTo(HaveOccurred(), "Failed to load test-app.yaml")
-
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
-		cmd.Stdin = strings.NewReader(appYAML)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create test application")
-
-		By("waiting for test application to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "test-app", "-n", testNamespace,
-				"-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, 2*time.Minute, time.Second).Should(Succeed(), func() string {
-			// Collect diagnostic information when deployment fails
-			diagnostics := "\n=== Deployment Diagnostic Information ===\n"
-
-			// Get deployment details
-			cmd := exec.Command("kubectl", "get", "deployment", "test-app", "-n", testNamespace, "-o", "yaml")
-			if output, err := utils.Run(cmd); err == nil {
-				diagnostics += "\nDeployment YAML:\n" + output + "\n"
-			}
-
-			// Get pod status
-			cmd = exec.Command("kubectl", "get", "pods", "-n", testNamespace, "-l", "app=test-app")
-			if output, err := utils.Run(cmd); err == nil {
-				diagnostics += "\nPod Status:\n" + output + "\n"
-			}
-
-			// Get pod details
-			cmd = exec.Command("kubectl", "describe", "pods", "-n", testNamespace, "-l", "app=test-app")
-			if output, err := utils.Run(cmd); err == nil {
-				diagnostics += "\nPod Details:\n" + output + "\n"
-			}
-
-			// Get events
-			cmd = exec.Command("kubectl", "get", "events", "-n", testNamespace, "--sort-by=.lastTimestamp")
-			if output, err := utils.Run(cmd); err == nil {
-				diagnostics += "\nNamespace Events:\n" + output + "\n"
-			}
-
-			return diagnostics
-		})
+		SetupTestNamespace(testNamespace)
+		DeployTestApp(testNamespace)
 	})
 
 	AfterAll(func() {
-		By("cleaning up test resources")
-		cmd := exec.Command("kubectl", "delete", "namespace", testNamespace, "--ignore-not-found")
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
+		CleanupTestNamespace(testNamespace)
 	})
 
 	It("should reconcile a NebariApp resource successfully", func() {

--- a/test/e2e/routing_test.go
+++ b/test/e2e/routing_test.go
@@ -37,16 +37,10 @@ var _ = Describe("NebariApp Routing Schema Variations", Ordered, func() {
 
 	BeforeAll(func() {
 		var err error
-
 		testNamespace = "e2e-test-routing"
 
-		By("installing NebariApp CRDs")
-		cmd := exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
 		By("checking if Gateway exists")
-		cmd = exec.Command("kubectl", "get", "gateway", "nebari-gateway", "-n", "envoy-gateway-system")
+		cmd := exec.Command("kubectl", "get", "gateway", "nebari-gateway", "-n", "envoy-gateway-system")
 		_, err = utils.Run(cmd)
 		if err != nil {
 			Skip("Gateway 'nebari-gateway' not found - run 'make setup' in dev/ first")
@@ -59,109 +53,14 @@ var _ = Describe("NebariApp Routing Schema Variations", Ordered, func() {
 		gatewayIP, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to get Gateway IP")
 		Expect(gatewayIP).NotTo(BeEmpty(), "Gateway IP is empty")
-
 		By(fmt.Sprintf("Gateway IP: %s", gatewayIP))
 
-		By("creating test namespace")
-		cmd = exec.Command("kubectl", "create", "namespace", testNamespace, "--dry-run=client", "-o", "yaml")
-		output, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred())
-
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
-		cmd.Stdin = strings.NewReader(output)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling namespace for Operator management")
-		cmd = exec.Command("kubectl", "label", "namespace", testNamespace, "nebari.dev/managed=true", "--overwrite")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace")
-			By("undeploying any existing controller-manager")
-			_, _ = utils.Run(exec.Command("make", "undeploy"))
-		By("waiting for operator namespace to be fully terminated from previous runs")
-		Eventually(func() error {
-			cmd = exec.Command("kubectl", "get", "namespace", "nebari-operator-system")
-			_, err = utils.Run(cmd)
-			return err
-		}, VeryLongTimeout, time.Second).Should(HaveOccurred(),
-			"nebari-operator-system should be absent before deploying")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-
-		By("waiting for controller-manager to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "nebari-operator-controller-manager",
-				"-n", "nebari-operator-system", "-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, 2*time.Minute, time.Second).Should(Succeed())
-
-		By("creating a test application deployment")
-		appYAML, err := utils.LoadTestDataFile("test-app.yaml", map[string]string{
-			"NAMESPACE_PLACEHOLDER": testNamespace,
-		})
-		Expect(err).NotTo(HaveOccurred(), "Failed to load test-app.yaml")
-
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
-		cmd.Stdin = strings.NewReader(appYAML)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create test application")
-
-		By("waiting for test application to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "test-app", "-n", testNamespace,
-				"-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, 2*time.Minute, time.Second).Should(Succeed(), func() string {
-			// Collect diagnostic information when deployment fails
-			diagnostics := "\n=== Deployment Diagnostic Information ===\n"
-
-			// Get deployment details
-			cmd := exec.Command("kubectl", "get", "deployment", "test-app", "-n", testNamespace, "-o", "yaml")
-			if output, err := utils.Run(cmd); err == nil {
-				diagnostics += "\nDeployment YAML:\n" + output + "\n"
-			}
-
-			// Get pod status
-			cmd = exec.Command("kubectl", "get", "pods", "-n", testNamespace, "-l", "app=test-app")
-			if output, err := utils.Run(cmd); err == nil {
-				diagnostics += "\nPod Status:\n" + output + "\n"
-			}
-
-			// Get pod details
-			cmd = exec.Command("kubectl", "describe", "pods", "-n", testNamespace, "-l", "app=test-app")
-			if output, err := utils.Run(cmd); err == nil {
-				diagnostics += "\nPod Details:\n" + output + "\n"
-			}
-
-			// Get events
-			cmd = exec.Command("kubectl", "get", "events", "-n", testNamespace, "--sort-by=.lastTimestamp")
-			if output, err := utils.Run(cmd); err == nil {
-				diagnostics += "\nNamespace Events:\n" + output + "\n"
-			}
-
-			return diagnostics
-		})
+		SetupTestNamespace(testNamespace)
+		DeployTestApp(testNamespace)
 	})
 
 	AfterAll(func() {
-		By("cleaning up test resources")
-		cmd := exec.Command("kubectl", "delete", "namespace", testNamespace, "--ignore-not-found", "--timeout=60s")
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
+		CleanupTestNamespace(testNamespace)
 	})
 
 	Context("TLS Configuration Variations", func() {

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -38,60 +38,11 @@ var _ = Describe("NebariApp Validation", Ordered, func() {
 	const testNamespace = "e2e-test-validation"
 
 	BeforeAll(func() {
-		var cmd *exec.Cmd
-		var err error
-
-		By("installing NebariApp CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
-		By("creating test namespace")
-		cmd = exec.Command("kubectl", "create", "namespace", testNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling namespace for Operator management")
-		cmd = exec.Command("kubectl", "label", "namespace", testNamespace, "nebari.dev/managed=true")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace")
-			By("undeploying any existing controller-manager")
-			_, _ = utils.Run(exec.Command("make", "undeploy"))
-		By("waiting for operator namespace to be fully terminated from previous runs")
-		Eventually(func() error {
-			cmd = exec.Command("kubectl", "get", "namespace", "nebari-operator-system")
-			_, err = utils.Run(cmd)
-			return err
-		}, VeryLongTimeout, PollInterval).Should(HaveOccurred(),
-			"nebari-operator-system should be absent before deploying")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-
-		By("waiting for controller-manager to be ready")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "get", "deployment", "nebari-operator-controller-manager",
-				"-n", "nebari-operator-system", "-o", "jsonpath={.status.availableReplicas}")
-			output, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(output).To(Equal("1"))
-		}, MediumTimeout, PollInterval).Should(Succeed())
+		SetupTestNamespace(testNamespace)
 	})
 
 	AfterAll(func() {
-		By("cleaning up test resources")
-		cmd := exec.Command("kubectl", "delete", "namespace", testNamespace, "--ignore-not-found")
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
+		CleanupTestNamespace(testNamespace)
 	})
 
 	Context("Service Reference Validation", func() {


### PR DESCRIPTION
## Summary

- Moves operator lifecycle (CRD install, deploy, undeploy) into `SynchronizedBeforeSuite`/`SynchronizedAfterSuite` so the operator deploys once and is shared across all test suites
- Extracts `SetupTestNamespace`, `DeployTestApp`, `CleanupTestNamespace` shared helpers to eliminate duplicated setup across 7 test files
- Each suite manages only its own namespace for isolation, enabling safe parallel execution
- `make test-e2e` now runs with `--procs=4` by default; `make test-e2e-serial` added for debugging
- Net result: -392 lines, eliminates 6 redundant deploy/undeploy cycles

## Test plan

- [ ] CI e2e tests pass (parallel by default)
- [ ] `make test-e2e-serial` still works for debugging
- [ ] `SKIP_SETUP=true make test-e2e` works against a pre-provisioned cluster
- [ ] Unit tests unaffected (`go test ./internal/...`)

Closes #72