### PR TITLE
Fix stale SecurityPolicy when auth is disabled

### DIFF
--- a/internal/controller/reconcilers/auth/reconciler.go
+++ b/internal/controller/reconcilers/auth/reconciler.go
@@ -72,9 +72,14 @@ func shouldEnforceAtGateway(auth *appsv1.AuthConfig) bool {
 func (r *AuthReconciler) ReconcileAuth(ctx context.Context, nebariApp *appsv1.NebariApp) error {
 	logger := log.FromContext(ctx)
 
-	// Skip if auth is not enabled
+	// Skip if auth is not enabled, but clean up any existing SecurityPolicy first
 	if nebariApp.Spec.Auth == nil || !nebariApp.Spec.Auth.Enabled {
-		logger.Info("Auth not enabled, skipping auth reconciliation")
+		logger.Info("Auth not enabled, cleaning up any existing SecurityPolicy")
+		if err := r.deleteSecurityPolicyIfExists(ctx, nebariApp); err != nil {
+			conditions.SetCondition(nebariApp, appsv1.ConditionTypeAuthReady, metav1.ConditionFalse,
+				"SecurityPolicyCleanupFailed", fmt.Sprintf("Failed to delete existing SecurityPolicy: %v", err))
+			return err
+		}
 		conditions.SetCondition(nebariApp, appsv1.ConditionTypeAuthReady, metav1.ConditionFalse,
 			"AuthDisabled", "Authentication is not enabled for this app")
 		return nil

--- a/internal/controller/reconcilers/auth/reconciler_test.go
+++ b/internal/controller/reconcilers/auth/reconciler_test.go
@@ -486,6 +486,28 @@ func TestReconcileAuth(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "Auth disabled with pre-existing SecurityPolicy - deletes it",
+			nebariApp: &appsv1.NebariApp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: appsv1.NebariAppSpec{
+					Hostname: "test.example.com",
+					Auth: &appsv1.AuthConfig{
+						Enabled: false,
+					},
+				},
+			},
+			existingSecurityPolicy: &egv1alpha1.SecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      naming.SecurityPolicyName(&appsv1.NebariApp{ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"}}),
+					Namespace: "default",
+				},
+			},
+			expectError: false,
+		},
+		{
 			name: "Auth enabled with valid config",
 			nebariApp: &appsv1.NebariApp{
 				ObjectMeta: metav1.ObjectMeta{
@@ -649,6 +671,18 @@ func TestReconcileAuth(t *testing.T) {
 			}
 			if !tt.expectError && err != nil {
 				t.Errorf("expected no error, got: %v", err)
+			}
+
+			// If auth is disabled and there was a pre-existing SecurityPolicy, verify it was deleted
+			if !tt.expectError && tt.nebariApp.Spec.Auth != nil && !tt.nebariApp.Spec.Auth.Enabled && tt.existingSecurityPolicy != nil {
+				securityPolicy := &egv1alpha1.SecurityPolicy{}
+				err := client.Get(context.Background(), types.NamespacedName{
+					Name:      naming.SecurityPolicyName(tt.nebariApp),
+					Namespace: tt.nebariApp.Namespace,
+				}, securityPolicy)
+				if err == nil {
+					t.Error("expected SecurityPolicy to be deleted when auth is disabled, but it still exists")
+				}
 			}
 
 			// If auth is enabled and no error, verify SecurityPolicy based on enforceAtGateway setting


### PR DESCRIPTION
## Summary

- When a NebariApp transitions from `auth.enabled: true` to `auth.enabled: false` (or the auth block is removed entirely), `ReconcileAuth` returns early at the "auth not enabled" check without cleaning up the existing Envoy `SecurityPolicy`. This leaves a stale SecurityPolicy enforcing OIDC authentication at the gateway even though auth has been disabled on the NebariApp.
- The fix moves the `deleteSecurityPolicyIfExists` call into the early-return path, so disabling auth also removes the gateway-level enforcement.
- Adds a test case that verifies a pre-existing SecurityPolicy is deleted when auth is disabled.

### Root cause

In `ReconcileAuth`, the early return for disabled auth (lines 76-81) skipped all downstream logic, including the `deleteSecurityPolicyIfExists` call that only ran in the `enforceAtGateway=false` branch (line 132). The cleanup path was only reachable when auth was **enabled** but `enforceAtGateway` was `false` — not when auth was disabled entirely.

```go
// Before: early return skips cleanup
if nebariApp.Spec.Auth == nil || !nebariApp.Spec.Auth.Enabled {
    logger.Info("Auth not enabled, skipping auth reconciliation")
    conditions.SetCondition(...)
    return nil  // SecurityPolicy left behind
}
```

```go
// After: cleanup runs before early return
if nebariApp.Spec.Auth == nil || !nebariApp.Spec.Auth.Enabled {
    logger.Info("Auth not enabled, cleaning up any existing SecurityPolicy")
    if err := r.deleteSecurityPolicyIfExists(ctx, nebariApp); err != nil {
        ...
    }
    conditions.SetCondition(...)
    return nil
}
```

## Test plan

- [x] Existing unit tests pass
- [x] New test case: "Auth disabled with pre-existing SecurityPolicy - deletes it"
- [ ] Manual verification: deploy a NebariApp with auth enabled, then disable auth and confirm the SecurityPolicy is removed