### PR TITLE
chore: remove deprecated helm/v1-alpha from PROJECT file

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -7,7 +7,6 @@ domain: nebari.dev
 layout:
 - go.kubebuilder.io/v4
 plugins:
-  helm.kubebuilder.io/v1-alpha: {}
   helm.kubebuilder.io/v2-alpha:
     manifests: dist/install.yaml
     output: dist


### PR DESCRIPTION
## Summary

Removes the stale `helm.kubebuilder.io/v1-alpha: {}` entry from the `PROJECT` file.

## What changed and why

The `helm/v1-alpha` plugin is deprecated. The repo is already fully on `helm/v2-alpha`:
- `PROJECT` already declares `helm.kubebuilder.io/v2-alpha` with the correct config
- `make helm-chart` already runs `kubebuilder edit --plugins=helm/v2-alpha --force`
- No committed chart directory exists to migrate

The v1-alpha entry was just a leftover that caused kubebuilder tooling to warn about a deprecated plugin. This is a one-line cleanup.

Closes #41