### PR TITLE
Consolidate Docker builds into GoReleaser and fix release pipeline

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -53,7 +53,7 @@ jobs:
         run: make vet
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.5.0
 
@@ -77,10 +77,10 @@ jobs:
     needs: lint
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -96,10 +96,10 @@ jobs:
       CLUSTER_NAME: test-cluster
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -110,10 +110,10 @@ jobs:
           cluster_name: test-cluster
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build operator image with cache
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: false
@@ -209,16 +209,16 @@ jobs:
     needs: lint
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Install kubebuilder
         run: |
@@ -239,10 +239,10 @@ jobs:
           cluster_name: test-cluster
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build nebari-operator image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: false
@@ -278,15 +278,15 @@ jobs:
             arch: arm64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         id: login
         continue-on-error: true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
@@ -305,7 +305,7 @@ jobs:
       - name: Build and push by digest
         id: build
         if: steps.login.outcome == 'success'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -318,7 +318,7 @@ jobs:
 
       - name: Build Docker image (without push)
         if: steps.login.outcome != 'success'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -337,7 +337,7 @@ jobs:
 
       - name: Upload digest
         if: steps.login.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -350,12 +350,12 @@ jobs:
     needs: build-multiarch
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         id: login
         continue-on-error: true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
@@ -370,7 +370,7 @@ jobs:
 
       - name: Download digests
         if: steps.login.outcome == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digest-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -52,12 +52,12 @@ jobs:
     needs: tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -77,139 +77,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker-build-push:
-    name: Build & Push (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    needs: tests
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            arch: amd64
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            arch: arm64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
-          provenance: false
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digest-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge-manifest:
-    name: Create Multi-Arch Manifest
-    runs-on: ubuntu-latest
-    needs: docker-build-push
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-            type=raw,value=latest
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digest-*
-          merge-multiple: true
-
-      - name: Create manifest list and push
-        run: |
-          cd ${{ runner.temp }}/digests
-          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ' ')
-          TAG_ARGS=""
-          for tag in $TAGS; do
-            TAG_ARGS="$TAG_ARGS --tag $tag"
-          done
-          docker buildx imagetools create \
-            $TAG_ARGS \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-
-      - name: Inspect manifest
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Build summary
-        run: |
-          echo "### Release Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Release**: ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Image**: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Platforms**: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
-          echo "**Tags**: latest, ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
-
   goreleaser:
-    name: Release Go Binaries
+    name: Release Binaries and Docker Images
     runs-on: ubuntu-latest
-    needs: [tests, merge-manifest]
+    needs: tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -220,19 +118,19 @@ jobs:
   publish-helm-chart:
     name: Package and Publish Helm Chart
     runs-on: ubuntu-latest
-    needs: [tests, merge-manifest, build-manifests]
+    needs: [tests, goreleaser, build-manifests]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: 'latest'
 
@@ -269,16 +167,16 @@ jobs:
     needs: publish-helm-chart
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: 'latest'
 

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,12 +5,7 @@ version: 2
 
 before:
   hooks:
-    # Clean up ignored files that may be in the git tree from release commits
-    - git checkout -- dist/ || true
-    - git clean -fd dist/ || true
-    # Ensure dependencies are up to date
     - go mod tidy
-    # Generate code
     - make generate
 
 builds:
@@ -96,6 +91,29 @@ release:
 
     - [Documentation](https://github.com/nebari-dev/nebari-operator/tree/{{ .Tag }}/docs)
     - [Report Issues](https://github.com/nebari-dev/nebari-operator/issues)
+
+dockers_v2:
+  - id: nebari-operator
+    dockerfile: Dockerfile.goreleaser
+    ids:
+      - manager
+    images:
+      - "quay.io/nebari/nebari-operator"
+    tags:
+      - "{{ .Tag }}"
+      - "{{ .Version }}"
+      - "sha-{{ .ShortCommit }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    build_flag_templates:
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=nebari-operator"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.source=https://github.com/nebari-dev/nebari-operator"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
 
 # Announcements (optional)
 announce:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -107,13 +107,13 @@ dockers_v2:
     platforms:
       - linux/amd64
       - linux/arm64
-    build_flag_templates:
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=nebari-operator"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.source=https://github.com/nebari-dev/nebari-operator"
-      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.title": "nebari-operator"
+      "org.opencontainers.image.version": "{{.Version}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.source": "https://github.com/nebari-dev/nebari-operator"
+      "org.opencontainers.image.licenses": "Apache-2.0"
 
 # Announcements (optional)
 announce:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,10 @@
+# Dockerfile for GoReleaser builds.
+# GoReleaser places pre-built binaries under $TARGETPLATFORM/<binary>.
+# The existing Dockerfile (multi-stage build from source) is still used for
+# PR and local development builds.
+FROM gcr.io/distroless/static:nonroot
+ARG TARGETPLATFORM
+WORKDIR /
+COPY ${TARGETPLATFORM}/manager /manager
+USER 65532:65532
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Summary
- Replaces 3 separate Docker CI jobs (build-push amd64, build-push arm64, merge-manifest) with GoReleaser `dockers_v2`, which builds multi-arch images and pushes manifest lists in a single step
- Fixes broken GoReleaser before hooks that caused `Release Go Binaries` to fail on every release since at least alpha.14
- Adds `Dockerfile.goreleaser` for release builds (existing Dockerfile kept for PR/dev builds)
- Fixes missing v-prefixed Docker tag so `install.yaml` image references resolve correctly
- Updates all GitHub Actions to Node.js 24-compatible versions to resolve deprecation warnings

## Context
The v0.1.0-alpha.16 release produced a broken container image (12KB, no binary) because the helm-repository workflow was pushing Helm OCI charts to the same `quay.io/nebari/nebari-operator:<tag>` path, overwriting the Docker image. Additionally, the push-by-digest approach left untagged per-platform images vulnerable to registry garbage collection.

GoReleaser's `dockers_v2` solves both issues by building and pushing tagged multi-arch images atomically as part of the release process.

See #100 for full details.

## Test plan
- [ ] CI passes lint, unit tests, and e2e tests on this PR
- [ ] GoReleaser config validates (check goreleaser step in a test release)
- [ ] Verify `Dockerfile.goreleaser` builds correctly with goreleaser's context layout
- [ ] After merge, create a test pre-release and verify the Docker image at quay.io contains `/manager` and runs correctly