### PR TITLE
chore: clean up release docs and Makefile e2e targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,16 +81,16 @@ test-unit-html: test-unit ## Generate HTML coverage report for unit tests.
 	@xdg-open unit-coverage.html 2>/dev/null || open unit-coverage.html 2>/dev/null || echo "Open unit-coverage.html in your browser"
 
 .PHONY: test-e2e
-test-e2e: manifests generate fmt vet ginkgo ## Run all e2e tests (parallel by default).
-	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMG=$(IMG) "$(GINKGO)" -v --procs=4 --tags=e2e --timeout=30m ./test/e2e/
+test-e2e: manifests generate fmt vet ## Run all e2e tests.
+	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMG=$(IMG) go test ./test/e2e -v -ginkgo.v -tags=e2e -timeout=30m
 
-.PHONY: test-e2e-serial
-test-e2e-serial: manifests generate fmt vet ginkgo ## Run e2e tests serially (for debugging).
-	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMG=$(IMG) "$(GINKGO)" -v --tags=e2e --timeout=30m ./test/e2e/
+.PHONY: test-e2e-parallel
+test-e2e-parallel: manifests generate fmt vet ## Run e2e tests in parallel (faster).
+	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) go test ./test/e2e -v -ginkgo.v -ginkgo.procs=4 -tags=e2e -timeout=30m
 
 .PHONY: test-e2e-smoke
-test-e2e-smoke: manifests generate fmt vet ginkgo ## Run quick smoke tests only.
-	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMG=$(IMG) "$(GINKGO)" -v --tags=e2e --timeout=10m --focus="should reconcile a NebariApp" ./test/e2e/
+test-e2e-smoke: manifests generate fmt vet ## Run quick smoke tests only.
+	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) go test ./test/e2e -v -ginkgo.v -ginkgo.focus="should reconcile a NebariApp" -tags=e2e -timeout=10m
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
@@ -219,9 +219,6 @@ prepare-release: ## [DEPRECATED] Use automated GitHub Actions workflow instead
 	@echo "See docs/maintainers/release-process.md for details"
 	@echo ""
 	@exit 1
-	sed -i.bak "s/^appVersion:.*/appVersion: \"$(APP_VERSION)\"/" dist/chart/Chart.yaml
-	rm -f dist/chart/Chart.yaml.bak
-	@echo "✅ Updated chart version to $(VERSION) and appVersion to $(APP_VERSION)"
 
 ##@ Deployment
 
@@ -262,7 +259,6 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
-GINKGO = $(LOCALBIN)/ginkgo
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
@@ -279,7 +275,6 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
-GINKGO_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2 2>/dev/null)
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -307,11 +302,6 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
-
-.PHONY: ginkgo
-ginkgo: $(GINKGO) ## Download ginkgo CLI locally if necessary.
-$(GINKGO): $(LOCALBIN)
-	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo,$(GINKGO_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/docs/maintainers/release-checklist.md
+++ b/docs/maintainers/release-checklist.md
@@ -37,22 +37,9 @@ git tag -a v1.2.3 -m "Release v1.2.3"
 git push origin v1.2.3
 ```
 
-### 3. Monitor the Release Workflow
+### 3. Create the GitHub Release
 
-Go to the [Actions tab](https://github.com/nebari-dev/nebari-operator/actions) and monitor the Release workflow:
-
-Wait for all jobs to complete (typically 5-10 minutes):
-- [ ] **tests**: Unit tests and linter pass
-- [ ] **build-manifests**: Generate and upload install.yaml
-- [ ] **docker-build-push**: Build multi-arch images
-- [ ] **merge-manifest**: Create multi-arch manifest
-- [ ] **goreleaser**: Build Go binaries
-- [ ] **publish-helm-chart**: Package and upload Helm chart
-- [ ] **sync-helm-repository**: Sync to helm-repository (if enabled)
-
-### 4. Create the GitHub Release
-
-Once the workflow completes successfully:
+The release workflow is triggered by publishing a GitHub release — it does **not** trigger on tag push alone.
 
 #### Option A: Via GitHub CLI (Recommended)
 
@@ -76,6 +63,19 @@ The `--generate-notes` flag automatically creates release notes from PR titles.
    - Add upgrade instructions if needed
    - Organize by feature/bugfix/docs
 7. Click "Publish release"
+
+### 4. Monitor the Release Workflow
+
+Go to the [Actions tab](https://github.com/nebari-dev/nebari-operator/actions) and monitor the Release workflow:
+
+Wait for all jobs to complete (typically 5-10 minutes):
+- [ ] **tests**: Unit tests and linter pass
+- [ ] **build-manifests**: Generate and upload install.yaml
+- [ ] **docker-build-push**: Build multi-arch images
+- [ ] **merge-manifest**: Create multi-arch manifest
+- [ ] **goreleaser**: Build Go binaries
+- [ ] **publish-helm-chart**: Package and upload Helm chart
+- [ ] **sync-helm-repository**: Sync to helm-repository (if enabled)
 
 ### 5. Verify the Release Artifacts
 
@@ -109,19 +109,20 @@ kubectl apply -f https://github.com/nebari-dev/nebari-operator/releases/download
 ### Test Helm Installation
 
 ```bash
-# Download and install from GitHub release
-helm install nebari-operator \
-  https://github.com/nebari-dev/nebari-operator/releases/download/v1.2.3/nebari-operator-1.2.3.tgz \
+# Install from OCI registry (after helm-repository sync)
+helm install nebari-operator oci://quay.io/nebari/charts/nebari-operator \
+  --version 1.2.3 \
   --create-namespace \
   --namespace nebari-operator-system
 ```
 
-Or, after helm-repository sync:
+Or install directly from the GitHub release artifact:
 
 ```bash
-helm repo add nebari https://nebari-dev.github.io/helm-repository
-helm repo update
-helm install nebari-operator nebari/nebari-operator --version 1.2.3
+helm install nebari-operator \
+  https://github.com/nebari-dev/nebari-operator/releases/download/v1.2.3/nebari-operator-1.2.3.tgz \
+  --create-namespace \
+  --namespace nebari-operator-system
 ```
 
 ### Announce the Release (Optional)

--- a/docs/maintainers/release-process.md
+++ b/docs/maintainers/release-process.md
@@ -95,14 +95,6 @@ gh release create v1.0.0 \
 2. Find the "Release" workflow run
 3. Monitor the progress of all jobs:
    - **tests**: Runs unit tests and linter
-   - **build-manifests**: Generates the install.yaml
-   - **docker-build-push**: Builds and pushes Docker images
-### Step 4: Monitor the Release Workflow
-
-1. Go to the "Actions" tab in your GitHub repository
-2. Find the "Release" workflow run
-3. Monitor the progress of all jobs:
-   - **tests**: Runs unit tests and linter
    - **build-manifests**: Generates and uploads install.yaml
    - **docker-build-push**: Builds Docker images for each architecture
    - **merge-manifest**: Creates multi-arch manifest and pushes to registry
@@ -155,19 +147,16 @@ The Helm chart package:
 
 ### Using Helm (Recommended)
 
-Install the operator using the Helm chart:
+Install the operator using the Helm chart from the OCI registry:
 
 ```bash
-# Add the release as a Helm repository (download the chart first)
-curl -LO https://github.com/nebari-dev/nebari-operator/releases/download/v1.0.0/nebari-operator-1.0.0.tgz
-
-# Install the chart
-helm install nebari-operator nebari-operator-1.0.0.tgz \
+helm install nebari-operator oci://quay.io/nebari/charts/nebari-operator \
+  --version 1.0.0 \
   --create-namespace \
   --namespace nebari-operator-system
 ```
 
-Or install directly from URL:
+Or install directly from the GitHub release artifact:
 
 ```bash
 helm install nebari-operator \


### PR DESCRIPTION
## Summary

Follow-up to #99 (closed in favor of #101). Carries over the non-overlapping changes: release doc fixes, Helm install example updates, and Makefile cleanup.

## Changes

### `docs/maintainers/release-checklist.md`
- Fix step ordering: the release workflow triggers on `release: published`, not on tag push — so the GitHub Release must be created **before** monitoring the workflow
- Update Helm install examples to use OCI registry path (`oci://quay.io/nebari/charts/nebari-operator`)

### `docs/maintainers/release-process.md`
- Remove duplicate "Step 4: Monitor the Release Workflow" section
- Update Helm install examples to use OCI registry path

### `Makefile`
- Migrate e2e test targets from `ginkgo` CLI to `go test` (removes the ginkgo binary as a build dependency)
- Rename `test-e2e-serial` to `test-e2e` (now the default) and `test-e2e` to `test-e2e-parallel`
- Remove unreachable `sed`/`rm` lines after `exit 1` in the `prepare-release` target
- Remove `GINKGO` binary and `GINKGO_VERSION` variable declarations
