### PR TITLE
fix: propagate SetControllerReference error in routing reconciler

### DIFF
--- a/internal/controller/reconcilers/routing/httproute.go
+++ b/internal/controller/reconcilers/routing/httproute.go
@@ -64,7 +64,13 @@ func (r *RoutingReconciler) ReconcileRouting(ctx context.Context, nebariApp *app
 	}
 
 	// Generate desired HTTPRoute
-	desiredRoute := r.buildHTTPRoute(nebariApp, gatewayName, tlsListenerName)
+	desiredRoute, err := r.buildHTTPRoute(nebariApp, gatewayName, tlsListenerName)
+	if err != nil {
+		logger.Error(err, "Failed to build HTTPRoute")
+		conditions.SetCondition(nebariApp, appsv1.ConditionTypeRoutingReady, metav1.ConditionFalse,
+			"BuildFailed", fmt.Sprintf("Failed to build HTTPRoute: %v", err))
+		return err
+	}
 
 	// Check if HTTPRoute already exists
 	existingRoute := &gatewayv1.HTTPRoute{}
@@ -73,7 +79,7 @@ func (r *RoutingReconciler) ReconcileRouting(ctx context.Context, nebariApp *app
 		Namespace: desiredRoute.Namespace,
 	}
 
-	err := r.Client.Get(ctx, routeKey, existingRoute)
+	err = r.Client.Get(ctx, routeKey, existingRoute)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Create new HTTPRoute
@@ -153,7 +159,7 @@ func (r *RoutingReconciler) CleanupHTTPRoute(ctx context.Context, nebariApp *app
 // buildHTTPRoute generates an HTTPRoute resource from NebariApp spec.
 // tlsListenerName overrides the default "https" section name when TLS is enabled
 // and a per-app TLS listener has been created by the TLS reconciler.
-func (r *RoutingReconciler) buildHTTPRoute(nebariApp *appsv1.NebariApp, gatewayName string, tlsListenerName string) *gatewayv1.HTTPRoute {
+func (r *RoutingReconciler) buildHTTPRoute(nebariApp *appsv1.NebariApp, gatewayName string, tlsListenerName string) (*gatewayv1.HTTPRoute, error) {
 	routeName := naming.HTTPRouteName(nebariApp)
 	namespace := gatewayv1.Namespace(constants.GatewayNamespace)
 
@@ -208,9 +214,11 @@ func (r *RoutingReconciler) buildHTTPRoute(nebariApp *appsv1.NebariApp, gatewayN
 	}
 
 	// Set owner reference for garbage collection
-	_ = controllerutil.SetControllerReference(nebariApp, route, r.Scheme)
+	if err := controllerutil.SetControllerReference(nebariApp, route, r.Scheme); err != nil {
+		return nil, fmt.Errorf("failed to set controller reference on HTTPRoute: %w", err)
+	}
 
-	return route
+	return route, nil
 }
 
 // buildHTTPRouteRules generates HTTPRoute rules based on NebariApp routes
@@ -302,7 +310,13 @@ func (r *RoutingReconciler) ReconcilePublicRoute(ctx context.Context, nebariApp 
 	logger.Info("Reconciling public route", "gateway", gatewayName, "hostname", nebariApp.Spec.Hostname,
 		"publicRoutes", nebariApp.Spec.Routing.PublicRoutes)
 
-	desiredRoute := r.buildPublicHTTPRoute(nebariApp, gatewayName, tlsListenerName)
+	desiredRoute, err := r.buildPublicHTTPRoute(nebariApp, gatewayName, tlsListenerName)
+	if err != nil {
+		logger.Error(err, "Failed to build public HTTPRoute")
+		conditions.SetCondition(nebariApp, appsv1.ConditionTypeRoutingReady, metav1.ConditionFalse,
+			"BuildFailed", fmt.Sprintf("Failed to build public HTTPRoute: %v", err))
+		return err
+	}
 
 	existingRoute := &gatewayv1.HTTPRoute{}
 	routeKey := client.ObjectKey{
@@ -310,7 +324,7 @@ func (r *RoutingReconciler) ReconcilePublicRoute(ctx context.Context, nebariApp 
 		Namespace: desiredRoute.Namespace,
 	}
 
-	err := r.Client.Get(ctx, routeKey, existingRoute)
+	err = r.Client.Get(ctx, routeKey, existingRoute)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if err := r.Client.Create(ctx, desiredRoute); err != nil {
@@ -375,7 +389,7 @@ func (r *RoutingReconciler) CleanupPublicHTTPRoute(ctx context.Context, nebariAp
 
 // buildPublicHTTPRoute generates an HTTPRoute for public routes that bypass OIDC authentication.
 // This route is separate from the main route so the SecurityPolicy only targets the main route.
-func (r *RoutingReconciler) buildPublicHTTPRoute(nebariApp *appsv1.NebariApp, gatewayName string, tlsListenerName string) *gatewayv1.HTTPRoute {
+func (r *RoutingReconciler) buildPublicHTTPRoute(nebariApp *appsv1.NebariApp, gatewayName string, tlsListenerName string) (*gatewayv1.HTTPRoute, error) {
 	routeName := naming.PublicHTTPRouteName(nebariApp)
 	namespace := gatewayv1.Namespace(constants.GatewayNamespace)
 
@@ -441,9 +455,11 @@ func (r *RoutingReconciler) buildPublicHTTPRoute(nebariApp *appsv1.NebariApp, ga
 		},
 	}
 
-	_ = controllerutil.SetControllerReference(nebariApp, route, r.Scheme)
+	if err := controllerutil.SetControllerReference(nebariApp, route, r.Scheme); err != nil {
+		return nil, fmt.Errorf("failed to set controller reference on public HTTPRoute: %w", err)
+	}
 
-	return route
+	return route, nil
 }
 
 // validateGateway checks if the specified gateway exists

--- a/internal/controller/reconcilers/routing/httproute_test.go
+++ b/internal/controller/reconcilers/routing/httproute_test.go
@@ -202,7 +202,10 @@ func TestBuildHTTPRoute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			route := reconciler.buildHTTPRoute(tt.nebariApp, tt.gatewayName, "")
+			route, err := reconciler.buildHTTPRoute(tt.nebariApp, tt.gatewayName, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			// Check basic metadata
 			if route.Name == "" {
@@ -253,6 +256,61 @@ func TestBuildHTTPRoute(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildHTTPRoute_SetControllerReferenceError(t *testing.T) {
+	// An empty scheme has no types registered, so SetControllerReference will
+	// fail because it cannot look up the GVK for NebariApp.
+	emptyScheme := runtime.NewScheme()
+
+	reconciler := &RoutingReconciler{
+		Scheme:   emptyScheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	nebariApp := &appsv1.NebariApp{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+		Spec: appsv1.NebariAppSpec{
+			Hostname: "test.nebari.local",
+			Service:  appsv1.ServiceReference{Name: "test-service", Port: 8080},
+		},
+	}
+
+	route, err := reconciler.buildHTTPRoute(nebariApp, "nebari-gateway", "")
+	if err == nil {
+		t.Error("expected error when scheme has no types registered, got nil")
+	}
+	if route != nil {
+		t.Error("expected nil route on error, got non-nil")
+	}
+}
+
+func TestBuildPublicHTTPRoute_SetControllerReferenceError(t *testing.T) {
+	emptyScheme := runtime.NewScheme()
+
+	reconciler := &RoutingReconciler{
+		Scheme:   emptyScheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	nebariApp := &appsv1.NebariApp{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+		Spec: appsv1.NebariAppSpec{
+			Hostname: "test.nebari.local",
+			Service:  appsv1.ServiceReference{Name: "test-service", Port: 8080},
+			Routing: &appsv1.RoutingConfig{
+				PublicRoutes: []appsv1.RouteMatch{{PathPrefix: "/health"}},
+			},
+		},
+	}
+
+	route, err := reconciler.buildPublicHTTPRoute(nebariApp, "nebari-gateway", "")
+	if err == nil {
+		t.Error("expected error when scheme has no types registered, got nil")
+	}
+	if route != nil {
+		t.Error("expected nil route on error, got non-nil")
 	}
 }
 
@@ -453,6 +511,60 @@ func TestReconcileRouting(t *testing.T) {
 	}
 }
 
+func TestReconcileRouting_BuildError(t *testing.T) {
+	// Use a properly initialised scheme for the fake client so validateGateway
+	// passes, but give the reconciler an empty scheme so SetControllerReference
+	// fails — confirming ReconcileRouting surfaces the error and sets the
+	// RoutingReady condition to False.
+	clientScheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(clientScheme)
+	_ = gatewayv1.Install(clientScheme)
+	_ = corev1.AddToScheme(clientScheme)
+
+	nebariApp := &appsv1.NebariApp{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+		Spec: appsv1.NebariAppSpec{
+			Hostname: "test.nebari.local",
+			Service:  appsv1.ServiceReference{Name: "test-service", Port: 8080},
+		},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.PublicGatewayName,
+			Namespace: constants.GatewayNamespace,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(clientScheme).
+		WithObjects(nebariApp, gateway).
+		Build()
+
+	reconciler := &RoutingReconciler{
+		Client:   fakeClient,
+		Scheme:   runtime.NewScheme(), // empty — causes SetControllerReference to fail
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := reconciler.ReconcileRouting(context.Background(), nebariApp, "")
+	if err == nil {
+		t.Fatal("expected error from ReconcileRouting when buildHTTPRoute fails, got nil")
+	}
+
+	// Confirm the condition is set so the failure is observable on the resource
+	var foundFalse bool
+	for _, cond := range nebariApp.Status.Conditions {
+		if cond.Type == appsv1.ConditionTypeRoutingReady && cond.Status == metav1.ConditionFalse {
+			foundFalse = true
+			break
+		}
+	}
+	if !foundFalse {
+		t.Error("expected RoutingReady condition to be set to False on build error")
+	}
+}
+
 func TestCleanupHTTPRoute(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = appsv1.AddToScheme(scheme)
@@ -600,7 +712,10 @@ func TestBuildPublicHTTPRoute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			route := reconciler.buildPublicHTTPRoute(tt.nebariApp, tt.gatewayName, "")
+			route, err := reconciler.buildPublicHTTPRoute(tt.nebariApp, tt.gatewayName, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			if route.Name != tt.expectedName {
 				t.Errorf("expected name=%s, got name=%s", tt.expectedName, route.Name)
@@ -877,7 +992,10 @@ func TestBuildHTTPRouteWithTLSListener(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reconciler := &RoutingReconciler{Scheme: scheme}
-			route := reconciler.buildHTTPRoute(tt.nebariApp, constants.PublicGatewayName, tt.tlsListenerName)
+			route, err := reconciler.buildHTTPRoute(tt.nebariApp, constants.PublicGatewayName, tt.tlsListenerName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if len(route.Spec.ParentRefs) == 0 {
 				t.Fatal("expected at least one ParentRef")
 			}
@@ -959,7 +1077,10 @@ func TestBuildHTTPRouteAnnotations(t *testing.T) {
 				},
 			}
 
-			route := reconciler.buildHTTPRoute(nebariApp, constants.PublicGatewayName, "")
+			route, err := reconciler.buildHTTPRoute(nebariApp, constants.PublicGatewayName, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			for k, want := range tt.expectedAnnotations {
 				got, ok := route.Annotations[k]


### PR DESCRIPTION
## Summary

- Change `buildHTTPRoute` and `buildPublicHTTPRoute` to return `(*gatewayv1.HTTPRoute, error)` instead of silently discarding the `SetControllerReference` error
- Propagate the error through `ReconcileRouting` and `ReconcilePublicRoute`
- Set `RoutingReady=False` condition on both error paths so the failure is observable on the resource
- Add `TestBuildHTTPRoute_SetControllerReferenceError`, `TestBuildPublicHTTPRoute_SetControllerReferenceError`, and `TestReconcileRouting_BuildError` to confirm error propagation and condition wiring

## Problem

Both builder functions were using a blank assignment to discard the error:

```go
_ = controllerutil.SetControllerReference(nebariApp, route, r.Scheme)
```

If this call fails, the HTTPRoute is created without an owner reference. When the NebariApp is later deleted, the orphaned HTTPRoute is never garbage collected.

## Changes

| File | Change |
|---|---|
| `routing/httproute.go` | `buildHTTPRoute` and `buildPublicHTTPRoute` now return `error`; callers handle it and set condition |
| `routing/httproute_test.go` | All call sites updated; three new error-path tests added |

## Reviewer guide

### How to test locally

1. Run the new tests directly:
   ```bash
   go test ./internal/controller/reconcilers/routing/... -v -run "SetControllerReference|BuildError"
   ```

2. Run the full routing suite to check for regressions:
   ```bash
   go test ./internal/controller/reconcilers/routing/...
   ```

3. To verify the orphan-prevention behaviour on a live cluster, delete a `NebariApp` and confirm its `HTTPRoute` is also removed:
   ```bash
   kubectl delete nebariapp <name> -n <namespace>
   kubectl get httproute -n <namespace>  # should be gone
   ```
   Before this fix, a failure in `SetControllerReference` would leave the `HTTPRoute` behind even after the `NebariApp` was deleted.

### What a regression looks like

If the error handling is removed or swallowed, `TestReconcileRouting_BuildError` will fail — it explicitly asserts that `ReconcileRouting` returns a non-nil error **and** sets `RoutingReady=False` when the build step fails.

Closes #31