### PR TITLE
Fix token exchange decision strategy to AFFIRMATIVE

### DIFF
--- a/internal/controller/reconcilers/auth/providers/keycloak.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak.go
@@ -371,7 +371,7 @@ func (p *KeycloakProvider) ConfigureTokenExchange(ctx context.Context, nebariApp
 		"id":               tokenExchangePermID,
 		"name":             fmt.Sprintf("token-exchange.permission.client.%s", internalID),
 		"type":             "scope",
-		"decisionStrategy": "UNANIMOUS",
+		"decisionStrategy": "AFFIRMATIVE",
 		"scopes":           []string{tokenExchangeScopeID},
 		"policies":         policyIDs,
 		"resources":        []string{gocloak.PString(mgmtPerms.Resource)},


### PR DESCRIPTION
## Summary
- Changes the token-exchange scope permission `decisionStrategy` from `UNANIMOUS` to `AFFIRMATIVE`
- With `UNANIMOUS`, all peer client policies must match — impossible since each represents a different client. Any token exchange request fails with `403: Client not allowed to exchange`
- With `AFFIRMATIVE`, any single matching peer client policy grants access, which is the correct behavior

## Test plan
- [x] Deploy nebi-pack with `tokenExchange.enabled: true` alongside data-science-pack
- [x] Verify JupyterHub can exchange tokens for a nebi-audience token via Keycloak
- [x] Verify multiple peer clients (jupyterhub, mlflow, etc.) can each independently exchange tokens