### PR TITLE
fix(auth/keycloak): use external Keycloak URL for browser-facing OIDC endpoints

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -215,6 +215,23 @@ func main() {
 			Config: authConfig.Keycloak,
 		}
 		oidcProviders[constants.ProviderKeycloak] = keycloakProvider
+
+		// KEYCLOAK_EXTERNAL_URL is the source for browser-facing OIDC endpoints
+		// (Authorization, EndSession) on generated SecurityPolicies. When unset,
+		// Envoy Gateway falls back to OIDC discovery against the in-cluster
+		// issuer URL, which only produces browser-reachable URLs if Keycloak's
+		// own frontendUrl is configured. Warn loudly so operators know to
+		// configure one of the two.
+		if authConfig.Keycloak.ExternalURL == "" {
+			setupLog.Info("WARNING: KEYCLOAK_EXTERNAL_URL is not set. " +
+				"NebariApp SecurityPolicies will leave browser-facing OIDC endpoints " +
+				"(authorizationEndpoint, endSessionEndpoint) unset, and Envoy Gateway " +
+				"will fall back to OIDC discovery against the in-cluster issuer. " +
+				"Browser OAuth2 redirects will only work if Keycloak's frontendUrl " +
+				"is configured to a publicly routable URL. Set KEYCLOAK_EXTERNAL_URL " +
+				"on this deployment OR configure Keycloak frontendUrl explicitly.")
+		}
+
 		setupLog.Info("Keycloak OIDC provider initialized successfully")
 	}
 

--- a/internal/controller/reconcilers/auth/providers/keycloak.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak.go
@@ -59,22 +59,53 @@ func (p *KeycloakProvider) internalRealmURL() string {
 		p.Config.Realm)
 }
 
+// externalRealmURL returns the publicly routable base URL for the Keycloak realm,
+// or empty string when KEYCLOAK_EXTERNAL_URL is not configured.
+func (p *KeycloakProvider) externalRealmURL() string {
+	if p.Config.ExternalURL == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/realms/%s",
+		strings.TrimRight(p.Config.ExternalURL, "/"),
+		p.Config.Realm)
+}
+
 // GetIssuerURL returns the internal cluster URL for the Keycloak realm.
 // Envoy uses this to fetch OIDC configuration from within the cluster.
 func (p *KeycloakProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {
 	return p.internalRealmURL(), nil
 }
 
-// GetEndpointOverrides returns internal cluster URLs for Keycloak's OIDC endpoints.
-// This avoids Envoy using the external HTTPS endpoints from the OIDC discovery
-// document, which may use a certificate not trusted by Envoy (e.g., self-signed).
+// GetEndpointOverrides returns OIDC endpoint URLs split by who actually hits
+// each endpoint:
+//
+//   - Token: server-side, called by the Envoy proxy in the OAuth2 back-channel.
+//     Uses the in-cluster Keycloak service URL: lower latency than the public
+//     URL, and avoids requiring Envoy to trust the public TLS chain (which can
+//     be a self-signed or staging issuer).
+//   - Authorization, EndSession: browser-facing. The user's browser is redirected
+//     to these URLs, so they MUST be the publicly routable Keycloak URL. Using
+//     the in-cluster URL causes the browser to fail DNS resolution and dead-end
+//     the OAuth2 flow.
+//
+// When KEYCLOAK_EXTERNAL_URL is not configured, Authorization and EndSession
+// are left unset; Envoy falls back to the values it discovers from the
+// OIDC discovery document fetched at the (in-cluster) issuer URL, which may or
+// may not be publicly reachable depending on Keycloak's frontendUrl. Setting
+// KEYCLOAK_EXTERNAL_URL is therefore strongly recommended in production.
 func (p *KeycloakProvider) GetEndpointOverrides(_ context.Context, _ *appsv1.NebariApp) (OIDCEndpointOverrides, error) {
-	base := p.internalRealmURL() + "/protocol/openid-connect"
-	return OIDCEndpointOverrides{
-		Token:         ptr.To(base + "/token"),
-		Authorization: ptr.To(base + "/auth"),
-		EndSession:    ptr.To(base + "/logout"),
-	}, nil
+	internalBase := p.internalRealmURL() + "/protocol/openid-connect"
+	overrides := OIDCEndpointOverrides{
+		Token: ptr.To(internalBase + "/token"),
+	}
+
+	if externalBase := p.externalRealmURL(); externalBase != "" {
+		externalProtocol := externalBase + "/protocol/openid-connect"
+		overrides.Authorization = ptr.To(externalProtocol + "/auth")
+		overrides.EndSession = ptr.To(externalProtocol + "/logout")
+	}
+
+	return overrides, nil
 }
 
 // GetExternalIssuerURL returns the publicly routable Keycloak issuer URL.

--- a/internal/controller/reconcilers/auth/providers/keycloak.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak.go
@@ -88,11 +88,18 @@ func (p *KeycloakProvider) GetIssuerURL(ctx context.Context, nebariApp *appsv1.N
 //     the in-cluster URL causes the browser to fail DNS resolution and dead-end
 //     the OAuth2 flow.
 //
-// When KEYCLOAK_EXTERNAL_URL is not configured, Authorization and EndSession
-// are left unset; Envoy falls back to the values it discovers from the
-// OIDC discovery document fetched at the (in-cluster) issuer URL, which may or
-// may not be publicly reachable depending on Keycloak's frontendUrl. Setting
-// KEYCLOAK_EXTERNAL_URL is therefore strongly recommended in production.
+// Fallback when KEYCLOAK_EXTERNAL_URL is unset: Authorization and EndSession
+// are returned as nil overrides. Envoy Gateway then triggers OIDC discovery
+// against the (in-cluster) issuer URL and uses whatever Authorization /
+// EndSession endpoints Keycloak advertises in the discovery document. That
+// path only produces publicly reachable URLs if Keycloak itself is configured
+// with a public-facing `frontendUrl` / `KC_HOSTNAME_URL` so its discovery
+// document advertises external URLs. In every other case the discovered
+// values will also be in-cluster and the browser flow will still dead-end.
+// Operators should set KEYCLOAK_EXTERNAL_URL on the nebari-operator
+// deployment OR configure Keycloak's frontendUrl explicitly. A startup
+// warning is logged when neither is configured (see KeycloakProvider's
+// constructor / config validation).
 func (p *KeycloakProvider) GetEndpointOverrides(_ context.Context, _ *appsv1.NebariApp) (OIDCEndpointOverrides, error) {
 	internalBase := p.internalRealmURL() + "/protocol/openid-connect"
 	overrides := OIDCEndpointOverrides{

--- a/internal/controller/reconcilers/auth/providers/keycloak.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak.go
@@ -117,10 +117,11 @@ func (p *KeycloakProvider) GetEndpointOverrides(_ context.Context, _ *appsv1.Neb
 
 // GetExternalIssuerURL returns the publicly routable Keycloak issuer URL.
 func (p *KeycloakProvider) GetExternalIssuerURL(ctx context.Context, nebariApp *appsv1.NebariApp) (string, error) {
-	if p.Config.ExternalURL == "" {
+	external := p.externalRealmURL()
+	if external == "" {
 		return "", fmt.Errorf("KEYCLOAK_EXTERNAL_URL not configured; required for external issuer URL")
 	}
-	return fmt.Sprintf("%s/realms/%s", strings.TrimRight(p.Config.ExternalURL, "/"), p.Config.Realm), nil
+	return external, nil
 }
 
 // GetClientID returns the OIDC client ID for the NebariApp.

--- a/internal/controller/reconcilers/auth/providers/keycloak_test.go
+++ b/internal/controller/reconcilers/auth/providers/keycloak_test.go
@@ -125,48 +125,88 @@ func TestKeycloakProvider_GetEndpointOverrides(t *testing.T) {
 		expected OIDCEndpointOverrides
 	}{
 		{
-			name: "Default configuration (Keycloak 26+ root context path)",
+			name: "Default configuration with ExternalURL (Keycloak 26+ root context path)",
 			kcConfig: config.KeycloakConfig{
 				Realm:                  "nebari",
 				IssuerServiceName:      "keycloak-keycloakx-http",
 				IssuerServiceNamespace: "keycloak",
 				IssuerServicePort:      8080,
 				IssuerContextPath:      "",
+				ExternalURL:            "https://keycloak.example.com",
 			},
 			expected: OIDCEndpointOverrides{
-				Token:         ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token"),
-				Authorization: ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/auth"),
-				EndSession:    ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/logout"),
+				// Token endpoint: server-to-server, Envoy proxy hits this in
+				// the back-channel. Stays on the in-cluster URL for latency.
+				Token: ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token"),
+				// Authorization + EndSession: browser front-channel. Must be
+				// the publicly routable URL, otherwise the browser cannot
+				// reach Keycloak.
+				Authorization: ptr.To("https://keycloak.example.com/realms/nebari/protocol/openid-connect/auth"),
+				EndSession:    ptr.To("https://keycloak.example.com/realms/nebari/protocol/openid-connect/logout"),
 			},
 		},
 		{
-			name: "Legacy /auth context path",
+			name: "Legacy /auth context path with ExternalURL",
 			kcConfig: config.KeycloakConfig{
 				Realm:                  "nebari",
 				IssuerServiceName:      "keycloak-keycloakx-http",
 				IssuerServiceNamespace: "keycloak",
 				IssuerServicePort:      8080,
 				IssuerContextPath:      "/auth",
+				ExternalURL:            "https://keycloak.example.com/auth",
 			},
 			expected: OIDCEndpointOverrides{
 				Token:         ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/token"),
-				Authorization: ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/auth"),
-				EndSession:    ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/protocol/openid-connect/logout"),
+				Authorization: ptr.To("https://keycloak.example.com/auth/realms/nebari/protocol/openid-connect/auth"),
+				EndSession:    ptr.To("https://keycloak.example.com/auth/realms/nebari/protocol/openid-connect/logout"),
 			},
 		},
 		{
-			name: "Custom deployment configuration",
+			name: "Custom deployment configuration with ExternalURL",
 			kcConfig: config.KeycloakConfig{
 				Realm:                  "custom-realm",
 				IssuerServiceName:      "custom-keycloak",
 				IssuerServiceNamespace: "auth",
 				IssuerServicePort:      9090,
 				IssuerContextPath:      "",
+				ExternalURL:            "https://auth.custom.example.com",
 			},
 			expected: OIDCEndpointOverrides{
 				Token:         ptr.To("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/token"),
-				Authorization: ptr.To("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/auth"),
-				EndSession:    ptr.To("http://custom-keycloak.auth.svc.cluster.local:9090/realms/custom-realm/protocol/openid-connect/logout"),
+				Authorization: ptr.To("https://auth.custom.example.com/realms/custom-realm/protocol/openid-connect/auth"),
+				EndSession:    ptr.To("https://auth.custom.example.com/realms/custom-realm/protocol/openid-connect/logout"),
+			},
+		},
+		{
+			name: "ExternalURL with trailing slash is normalized",
+			kcConfig: config.KeycloakConfig{
+				Realm:                  "nebari",
+				IssuerServiceName:      "keycloak-keycloakx-http",
+				IssuerServiceNamespace: "keycloak",
+				IssuerServicePort:      8080,
+				IssuerContextPath:      "",
+				ExternalURL:            "https://keycloak.example.com/",
+			},
+			expected: OIDCEndpointOverrides{
+				Token:         ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token"),
+				Authorization: ptr.To("https://keycloak.example.com/realms/nebari/protocol/openid-connect/auth"),
+				EndSession:    ptr.To("https://keycloak.example.com/realms/nebari/protocol/openid-connect/logout"),
+			},
+		},
+		{
+			name: "No ExternalURL: only Token override is set; Envoy falls back to discovery for Authorization and EndSession",
+			kcConfig: config.KeycloakConfig{
+				Realm:                  "nebari",
+				IssuerServiceName:      "keycloak-keycloakx-http",
+				IssuerServiceNamespace: "keycloak",
+				IssuerServicePort:      8080,
+				IssuerContextPath:      "",
+				ExternalURL:            "",
+			},
+			expected: OIDCEndpointOverrides{
+				Token:         ptr.To("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token"),
+				Authorization: nil,
+				EndSession:    nil,
 			},
 		},
 	}
@@ -181,11 +221,21 @@ func TestKeycloakProvider_GetEndpointOverrides(t *testing.T) {
 			if got.Token == nil || *got.Token != *tt.expected.Token {
 				t.Errorf("token: expected %q, got %v", *tt.expected.Token, got.Token)
 			}
-			if got.Authorization == nil || *got.Authorization != *tt.expected.Authorization {
-				t.Errorf("authorization: expected %q, got %v", *tt.expected.Authorization, got.Authorization)
+			switch {
+			case tt.expected.Authorization == nil && got.Authorization != nil:
+				t.Errorf("authorization: expected nil, got %q", *got.Authorization)
+			case tt.expected.Authorization != nil && got.Authorization == nil:
+				t.Errorf("authorization: expected %q, got nil", *tt.expected.Authorization)
+			case tt.expected.Authorization != nil && got.Authorization != nil && *got.Authorization != *tt.expected.Authorization:
+				t.Errorf("authorization: expected %q, got %q", *tt.expected.Authorization, *got.Authorization)
 			}
-			if got.EndSession == nil || *got.EndSession != *tt.expected.EndSession {
-				t.Errorf("endSession: expected %q, got %v", *tt.expected.EndSession, got.EndSession)
+			switch {
+			case tt.expected.EndSession == nil && got.EndSession != nil:
+				t.Errorf("endSession: expected nil, got %q", *got.EndSession)
+			case tt.expected.EndSession != nil && got.EndSession == nil:
+				t.Errorf("endSession: expected %q, got nil", *tt.expected.EndSession)
+			case tt.expected.EndSession != nil && got.EndSession != nil && *got.EndSession != *tt.expected.EndSession:
+				t.Errorf("endSession: expected %q, got %q", *tt.expected.EndSession, *got.EndSession)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Split SecurityPolicy OIDC endpoint overrides by audience: Token stays on the in-cluster URL (Envoy back-channel), Authorization and EndSession move to the public URL (browser front-channel).
- Adds an `externalRealmURL()` helper mirroring `internalRealmURL()`.
- When `KEYCLOAK_EXTERNAL_URL` is unset, leaves Authorization/EndSession unset; Envoy Gateway then triggers OIDC discovery against the in-cluster issuer. Discovery only produces public URLs if Keycloak's own `frontendUrl` is configured. Operator now logs a startup warning so this trap is visible.
- Updated `TestKeycloakProvider_GetEndpointOverrides` with five cases covering the split, trailing-slash normalization, and the no-ExternalURL fallback.

## Why
On a clean NIC deploy, browsers hitting any NebariApp protected by Keycloak OAuth2 are redirected to `http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080` - which the browser cannot resolve. The OAuth2 flow dead-ends and no UI is reachable.

Surfaced during fresh-install validation of the Nebari LLM Serving Pack (nebari-dev/nebari-llm-serving-pack#65), which loads the key-manager UI as a NebariApp.

Closes #110

## Follow-ups (deliberately out of scope here)
- #112 - Should `SecurityPolicy.spec.oidc.provider.Issuer` also track `KEYCLOAK_EXTERNAL_URL` to match the `iss` claim in tokens issued by Keycloak with `frontendUrl` configured?
- #113 - Add a reconciler-level test asserting Token on in-cluster URL and Authorization+EndSession on public URL end-to-end through `buildSecurityPolicySpec`.

## Test plan
- [x] `go test ./internal/controller/reconcilers/auth/providers/...` passes - five cases covering the split, trailing-slash normalization, no-ExternalURL fallback
- [x] `go test ./...` no regressions vs main (pre-existing `TestControllers` HTTPRoute scheme failure unrelated)
- [x] `go build ./...` clean
- [ ] Validation against the llmd-validate cluster: build the operator image, swap it in via a temporary override on NIC's nebari-operator Application, confirm the rendered SecurityPolicy now uses `https://keycloak.<base>` for Authorization+EndSession, confirm browser login completes