### PR TITLE
ci(build-pr): bump azure/setup-helm to v5 and actions/github-script to v9

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -169,7 +169,7 @@ jobs:
           EOF
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Install foundational services
         run: dev/scripts/services/install.sh
@@ -418,7 +418,7 @@ jobs:
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branchTag = '${{ steps.branch.outputs.tag }}';


### PR DESCRIPTION
## Summary

Upgrades the two Node 20 actions in `build-pr.yml` that GitHub's runner currently warns about. Both fire on every PR.

| Line | From | To | Notes |
|---|---|---|---|
| 172 | `azure/setup-helm@v4` | `@v5` | `@v5` is already used in the same file at line 228 — this is an inconsistent pin, fix is a trivial digit bump. |
| 421 | `actions/github-script@v7` | `@v9` | v8/v9 (Node 24) shipped 2025-09 / 2026-04. v9 has breaking changes around `require('@actions/github')` and `getOctokit` redeclaration; neither is used by our comment script (it only touches the injected `github` and `context` parameters). |

Two-line diff.

## Why

GitHub deprecation timeline (<https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>):

- **2026-06-02** — actions forced to Node 24 by default.
- **2026-09-16** — Node 20 removed from runners.

The full repo audit is in #124. `release.yml` has two further Node-20 bumps (`docker/setup-qemu-action`, `softprops/action-gh-release`); both are major version bumps and ride in a separate PR for review focus.

## Test plan

- [ ] PR triggers `build-pr.yml` and the deprecation warning no longer appears for the `Set up Helm` and `Comment on PR` steps.
- [ ] `Comment on PR` step still posts the Docker image comment correctly (it'll post one on this PR itself).
- [ ] E2E job (Helm install path) still works.

Fixes part of #124.
