### PR TITLE
ci(release): bump docker/setup-qemu-action to v4 and softprops/action-gh-release to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         run: make build-installer IMG="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
 
       - name: Upload installer to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/install.yaml
         env:
@@ -97,7 +97,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Set up QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Log in to Quay.io
         uses: docker/login-action@v4
@@ -154,7 +154,7 @@ jobs:
         run: make helm-package
 
       - name: Upload Helm chart to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/*.tgz


### PR DESCRIPTION
## Summary

Upgrades the two remaining Node-20 actions in `release.yml`. Three-line diff. These don't trigger the deprecation warning on every PR (release workflow only runs on tags), but they're on the same Node 20 deprecation deadline.

| Line | From | To | Risk |
|---|---|---|---|
| 100 | `docker/setup-qemu-action@v3` | `@v4` | Runtime-only major (Node 24). No inputs renamed, no behavior changes. |
| 74, 157 | `softprops/action-gh-release@v2` | `@v3` | Runtime-only major (Node 24). v2 syntax fully compatible. |

## Release-notes review (the reason this rides separately from #125)

Both are major version bumps but functionally just Node 24 runtime bumps:

**`docker/setup-qemu-action@v4.0.0`** ([release](https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0)):
- Only meaningful change: Node 24 default runtime.
- Plus internal ESM switch and dependency refreshes (`@actions/core` 1.11.1 → 3.0.0 etc.).
- **Caveat:** requires Actions Runner v2.327.1 or later. GitHub-hosted runners are well past this; relevant only for self-hosted runners we don't have.

**`softprops/action-gh-release@v3.0.0`** ([release](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0)):
- Only change: runtime bump from Node 20 to Node 24, `@types/node` refresh.
- Maintainer explicitly says: "Use `v3` on GitHub-hosted runners and self-hosted fleets that already support the Node 24 Actions runtime."
- Existing `with: files:` syntax unchanged.

## Why

GitHub deprecation timeline (<https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>):

- **2026-06-02** — actions forced to Node 24 by default.
- **2026-09-16** — Node 20 removed from runners.

## Test plan

The release workflow only fires on tag push, so this can't be smoke-tested via a PR run. Recommended verification:

- [ ] Once merged, cut a pre-release tag (e.g. `v0.x.y-rc1`) and confirm:
    - The release workflow runs without Node-20 deprecation warnings.
    - Both `Upload installer to release` steps still attach `dist/install.yaml` and `dist/*.tgz` to the GitHub Release.
    - The multi-arch image push still works (QEMU step is needed for arm64).

Fixes part of #124. `build-pr.yml` upgrades are in #125.
