### PR TITLE
ci(release): pass IMG to make helm-chart so values.yaml inherits the pinned image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,8 +142,7 @@ jobs:
 
       - name: Generate Helm chart
         run: |
-          make build-installer IMG="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
-          make helm-chart
+          make helm-chart IMG="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
 
       - name: Update Chart version and appVersion
         run: |
@@ -188,8 +187,7 @@ jobs:
 
       - name: Generate Helm chart
         run: |
-          make build-installer IMG="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
-          make helm-chart
+          make helm-chart IMG="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
 
       - name: Update Chart version and appVersion
         run: |


### PR DESCRIPTION
## Summary

Fixes #127. Four-line diff — two identical edits, one per release-workflow job.

Kubebuilder's helm/v2-alpha plugin **already** extracts the controller-manager image from `dist/install.yaml`'s Deployment and splits it into `manager.image.{repository,tag}` in the generated `values.yaml`. The relevant logic is `extractContainerImage` in [kubernetes-sigs/kubebuilder `pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go`](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go) — for a tag-based image (`repo:tag`), it strips the tag off and writes both parts into `values.yaml`.

So the bug isn't in the chart shape; it's in **how the release pipeline invokes the plugin.**

## Root cause

In the `publish-helm-chart` and `sync-helm-repository` jobs the step was:

```yaml
- name: Generate Helm chart
  run: |
    make build-installer IMG="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
    make helm-chart
```

Both targets are `.PHONY` and `helm-chart` depends on `build-installer`. So `make helm-chart` on the second line re-runs `build-installer` — this time **without `IMG` set on the command line.** The Makefile then falls back to its default:

```makefile
IMG ?= nebari-operator:latest
```

Kustomize rewrites the deployment's image back to `nebari-operator:latest` in `dist/install.yaml`, and kubebuilder's helm plugin faithfully extracts *that* into `values.yaml`. Result: the published chart ships with `repository: nebari-operator` and `tag: latest` even though the matching release pushed a registry-qualified, version-tagged image.

## Fix

Pass `IMG` to `make helm-chart` directly. Make's dependency resolution then runs `build-installer` once with the right `IMG`, and the rest of the chain works as kubebuilder intends:

```yaml
- name: Generate Helm chart
  run: |
    make helm-chart IMG="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
```

No Makefile changes. No post-generation sed. No risk of drifting from whatever kubebuilder's extractor logic happens to be.

## Comparison vs. the previous approach on this branch

The earlier draft of this PR extended `make helm-chart-version` to sed-stamp `manager.image.repository` and `manager.image.tag` into `values.yaml` after kubebuilder ran. That worked, but it was unnecessary — kubebuilder already does the same job natively, just from `dist/install.yaml`. The branch is force-pushed to the smaller fix.

## Local verification

```
$ make helm-chart IMG=quay.io/nebari/nebari-operator:v0.1.0-alpha.20
...
INFO Helm Chart generation completed successfully

$ grep -B 1 -A 3 '^  image:' dist/chart/values.yaml | head -5
  image:
    repository: quay.io/nebari/nebari-operator
    tag: v0.1.0-alpha.20
    pullPolicy: IfNotPresent
```

## Test plan

The release workflow only fires on tag push, so this can't be smoke-tested via a PR run. Once merged, cut a pre-release tag (e.g. `v0.1.0-alpha.20`) and confirm:

- [ ] `publish-helm-chart` and `sync-helm-repository` jobs complete without errors.
- [ ] The packaged `nebari-operator-0.1.0-alpha.20.tgz` uploaded to the GitHub Release has `manager.image.repository: quay.io/nebari/nebari-operator` and `manager.image.tag: v0.1.0-alpha.20` in its `values.yaml`.
- [ ] The synced chart at `nebari-dev/helm-repository/charts/nebari-operator/values.yaml` shows the same.
- [ ] A vanilla `helm install` of the synced chart (no value overrides) produces a Deployment with `image: quay.io/nebari/nebari-operator:v0.1.0-alpha.20`.

## Out of scope

- Whether to stop pushing `:latest` from goreleaser. Per the issue discussion, `:latest` is expected behavior for users running off main; the important thing is that the chart and image pair are pinned at release. That's what this PR ensures.

## Related

- Issue: #127
- Same pattern (chart defaulting to `:latest`) in landing-page: nebari-dev/nebari-landing#82
