### PR TITLE
chore(manager): tighten Deployment manifest defaults

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,6 +56,8 @@ spec:
         # For more details, see: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         runAsNonRoot: true
         runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -68,7 +70,14 @@ spec:
         imagePullPolicy: IfNotPresent
         name: manager
         env:
-          # Keycloak OIDC Provider Configuration
+          # Keycloak OIDC Provider Configuration.
+          #
+          # KEYCLOAK_ADMIN_SECRET_NAME and KEYCLOAK_ADMIN_SECRET_NAMESPACE are
+          # the *name* and *namespace* of a Kubernetes Secret — not the
+          # credentials themselves.  The operator reads them at runtime via
+          # its ServiceAccount.  Static-analysis tools sometimes flag plain
+          # string env vars whose names match `*_SECRET_*` patterns; in this
+          # case the values are intentional pointers, not sensitive data.
           - name: KEYCLOAK_ENABLED
             value: "true"
           - name: KEYCLOAK_URL
@@ -87,7 +96,10 @@ spec:
           #     secretKeyRef:
           #       name: keycloak-admin-credentials
           #       key: admin-password
-        ports: []
+        ports:
+          - name: health
+            containerPort: 8081
+            protocol: TCP
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Three small Kubernetes-best-practice additions on the controller-manager Deployment template (`config/manager/manager.yaml`). No code change, no runtime behaviour change.

| Change | What | Why |
|---|---|---|
| Add `runAsGroup: 65532` + `fsGroup: 65532` | pod-level `securityContext` | Pod already runs `runAsUser: 65532` / `runAsNonRoot: true`. Setting the matching group keeps uid/gid consistent across the pod and avoids inheriting whatever default group the base image ships with. |
| Declare `containerPort: 8081, name: health` | manager container `ports` | Probes already used `:8081` via `--health-probe-bind-address`, but the container's `ports` was empty. Manifest hygiene — common lint rule. |
| Inline comment on `KEYCLOAK_ADMIN_SECRET_*` env vars | env-var documentation | Those env vars hold Secret *pointers* (name + namespace), not credential values. Some static-analysis rules flag env var names matching `*_SECRET_*` patterns; the comment makes the intent explicit so future linters and reviewers don't re-relitigate the question. |

## Verification

- [x] `go build ./...` — passes
- [x] `make lint` — 0 issues
- [x] `make build-installer IMG=...` renders the expected fields into `dist/install.yaml` (verified locally: `runAsGroup`, `fsGroup`, the `health` containerPort all present)
- [ ] CI re-renders `dist/chart/` via the release pipeline on next tag — pure manifest changes propagate automatically

## Related

- Routine manifest hygiene as part of the v0.1.0 readiness pass (#129).
- File-level independent of #133 (Go dep bumps) and the upcoming RBAC narrow PR — can land in any order.
