### PR TITLE
chore(test): tighten path handling in test utilities

### DIFF
--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -246,13 +247,21 @@ func GetNonEmptyLines(output string) []string {
 // LoadTestDataFile reads a YAML file from the testdata directory and replaces placeholders.
 // The replacements map contains key-value pairs where keys are placeholders to be replaced
 // with their corresponding values.
+//
+// filename is constrained to stay within test/e2e/testdata/ — `..` traversal is rejected.
 func LoadTestDataFile(filename string, replacements map[string]string) (string, error) {
 	projectDir, err := GetProjectDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get project directory: %w", err)
 	}
 
-	filePath := fmt.Sprintf("%s/test/e2e/testdata/%s", projectDir, filename)
+	testdataDir := filepath.Join(projectDir, "test", "e2e", "testdata")
+	filePath := filepath.Clean(filepath.Join(testdataDir, filename))
+	rel, err := filepath.Rel(testdataDir, filePath)
+	if err != nil || strings.HasPrefix(rel, "..") || strings.Contains(rel, string(filepath.Separator)+"..") {
+		return "", fmt.Errorf("invalid filename %q: must be inside test/e2e/testdata/", filename)
+	}
+
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
@@ -330,9 +339,7 @@ func UncommentCode(filename, target, prefix string) error {
 		return fmt.Errorf("failed to write to output: %w", err)
 	}
 
-	// false positive
-	// nolint:gosec
-	if err = os.WriteFile(filename, out.Bytes(), 0644); err != nil {
+	if err = os.WriteFile(filename, out.Bytes(), 0600); err != nil {
 		return fmt.Errorf("failed to write file %q: %w", filename, err)
 	}
 


### PR DESCRIPTION
## Summary

Two small hygiene fixes in `test/utils/utils.go`. Test-utility code only — no operator runtime impact.

| Change | Where |
|---|---|
| Constrain `LoadTestDataFile`'s `filename` to stay inside `test/e2e/testdata/` (reject `..` traversal). Replaces raw string concat with `filepath.Join` + `filepath.Rel` check. | `LoadTestDataFile` |
| Write fixture files with mode `0600` instead of `0644`. Test fixtures don't need group/other readability; the existing `nolint:gosec` workaround for the rule comes off. | `UncommentCode` |

## Verification

- [x] `go build ./...` — passes
- [x] `make lint` — 0 issues
- [x] `test/utils/` has no test files; nothing new to run. E2E tests that import the package still build cleanly.

## Why now

Routine test-utility hygiene as part of the v0.1.0 readiness pass (#129). File-level independent of #133 (deps) and #134 (manifest) — can land in any order.
