### PR TITLE
ci: cap the E2E job with timeout-minutes

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -99,6 +99,10 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: lint
+    # Hard cap so a hung setup step (e.g. an unbounded wait while installing
+    # foundational services) fails the job in minutes instead of squatting a
+    # runner until GitHub's 6h default. A healthy run finishes well under this.
+    timeout-minutes: 30
     env:
       CLUSTER_NAME: test-cluster
     steps:


### PR DESCRIPTION
## Summary

Add a `timeout-minutes: 30` cap to the `test-e2e` job. It had no timeout, so a hung setup step ran until GitHub's 6-hour default, holding a runner the entire time.

## Why

On a recent PR the `Install foundational services` step (`dev/scripts/services/install.sh`) wedged — apparently on an unbounded readiness wait — and the job sat in-progress for 40+ minutes with no end in sight (it would have run to 6h). That step runs *before* the operator is even deployed, so it's an environment/setup hang, not a code failure. A job-level cap is the robust backstop regardless of which inner command stalls.

A healthy E2E run finishes well under 30 minutes (the foundational step normally completes in ~2 min), so this only ever trips on a genuine hang — failing it in minutes instead of squatting a runner.

## Scope

Deliberately minimal and standalone. The strategic fix — replacing the hand-rolled `dev/scripts/services/*` setup with the `nebari-dev/action-nebari-sandbox` `platform` profile — is a larger, multi-repo effort tracked separately. This just stops the bleeding in the meantime.

## Test plan

- YAML parses; `jobs.test-e2e.timeout-minutes == 30`.
- No behavior change on healthy runs; only bounds hangs.
