### PR TITLE
fix: harden nebari-app required-field guards (port >= 1, missing service)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,22 @@ helm-test: helm-lint-library ## Render the nebari-app library chart for all case
 		) || { echo >&2 "expected required failure for $$f"; exit 1; }; \
 		echo "  required guard $$f: ok"; \
 	done
+	@# Verify the whole service block is guarded: render with an empty service, expect error
+	@( set +o pipefail; \
+		helm template t test/helm/nebari-app \
+			--set cases.minimal.enabled=true \
+			--set "cases.minimal.spec.service=" \
+			2>&1 >/dev/null | grep -q "spec.service is required" \
+	) || { echo >&2 "expected required failure for empty spec.service"; exit 1; }
+	@echo "  required guard spec.service: ok"
+	@# Verify port positivity is enforced client-side: port=0 must fail before the API server
+	@( set +o pipefail; \
+		helm template t test/helm/nebari-app \
+			--set cases.minimal.enabled=true \
+			--set "cases.minimal.spec.service.port=0" \
+			2>&1 >/dev/null | grep -q "must be >= 1" \
+	) || { echo >&2 "expected sub-minimum failure for spec.service.port=0"; exit 1; }
+	@echo "  positivity guard spec.service.port=0: ok"
 	@echo "✅ nebari-app chart tests passed"
 
 .PHONY: generate-dev

--- a/charts/nebari-app/templates/_nebari-app.tpl
+++ b/charts/nebari-app/templates/_nebari-app.tpl
@@ -1,8 +1,10 @@
 {{- define "nebari-app.nebariApp" -}}
 {{- $_ := required "metadata.name is required" .metadata.name -}}
 {{- $_ := required "spec.hostname is required" .spec.hostname -}}
+{{- $_ := required "spec.service is required" .spec.service -}}
 {{- $_ := required "spec.service.name is required" .spec.service.name -}}
 {{- $_ := required "spec.service.port is required" .spec.service.port -}}
+{{- if lt (int .spec.service.port) 1 -}}{{- fail "spec.service.port must be >= 1" -}}{{- end -}}
 apiVersion: reconcilers.nebari.dev/v1
 kind: NebariApp
 metadata:


### PR DESCRIPTION
The `nebariApp` library template guarded `spec.service` sub-fields with Helm's `required`, but two gaps let invalid input reach the API server. A missing `spec.service` block dereferenced `.spec.service.name`/`.spec.service.port` and yielded a nil-pointer error instead of a clean message, and `port: 0` passed the guard because `required` only fails on nil/empty-string (it renders `0`), so it failed only server-side on the CRD's `minimum: 1`.

This adds a `required` guard on `.spec.service` before the sub-field guards, plus an explicit `fail` when `spec.service.port < 1` to reject 0 and negatives client-side. Valid renders stay byte-identical (chomping preserved), so the existing golden files are unchanged.

## Test plan
- `make helm-lint-library` passes.
- `make helm-test` passes: all four golden cases still diff-match unchanged, and the required-guard verification block now also asserts an empty `spec.service` triggers "spec.service is required" and `spec.service.port=0` triggers "must be >= 1".

Closes #172
