### PR TITLE
docs: adopt Effort-based Versioning (EffVer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@
 
 
 
-> **Status**: Under active development as part of Nebari Infrastructure Core (NIC). APIs and behavior may change without
-> notice.
+> **Status**: Pre-1.0 and under active development as part of Nebari Infrastructure Core (NIC). The project follows
+> [Effort-based Versioning](https://jacobtomlinson.dev/effver/): while the major version is `0`, CRD fields and behavior
+> can still change between releases — watch the MACRO (leftmost) digit for upgrades that need manifest changes.
 
 ## What is Nebari Operator?
 

--- a/docs/decisions/2026-08-14-adopt-effver.md
+++ b/docs/decisions/2026-08-14-adopt-effver.md
@@ -1,0 +1,66 @@
+# ADR-003: Adopt Effort-based Versioning (EffVer)
+
+| Field       | Value                               |
+|-------------|-------------------------------------|
+| Date        | 2026-08-14                          |
+| Status      | **Accepted**                        |
+| Deciders    | NIC maintainers                     |
+| Supersedes  | —                                   |
+
+## Context
+
+The operator has shipped twenty pre-releases on the `v0.1.0-alpha.N` line and is preparing its first non-alpha cut, `v0.1.0` (tracked in #129). Before that cut we need a stated versioning policy; the maintainer docs currently point at [Semantic Versioning](https://semver.org/).
+
+SemVer communicates *API compatibility* - a bump says whether the public interface changed in a breaking way. That is a poor fit for where this project is:
+
+1. Pre-1.0, the CRD schema is still moving. Under SemVer nearly every useful change to a `NebariApp` field is a breaking change that would warrant a major bump - so the major number either sprints ahead meaninglessly or we quietly violate the spec on minor bumps, which is effectively what happened across the alpha line.
+2. What a consumer actually needs to know - whether a pack author writing `NebariApp` manifests or a maintainer upgrading a cluster - is not "did the API technically break" but "how much work is this upgrade going to be." SemVer does not answer that directly.
+
+[Effort-based Versioning (EffVer)](https://jacobtomlinson.dev/effver/) keeps the same `MACRO.MESO.MICRO` shape but reinterprets each digit as the *effort a consumer should expect when adopting the release*.
+
+## Decision
+
+Adopt EffVer as the operator's versioning policy, starting with `v0.1.0`.
+
+| EffVer component | Meaning for a NebariApp consumer / pack author |
+|---|---|
+| **MACRO** (`X.y.z`) | "Expect significant changes." CRD shape moved meaningfully; you will touch your pack manifests. |
+| **MESO** (`x.Y.z`) | "Could break, watch for warnings." New fields, optional opt-ins, deprecations. |
+| **MICRO** (`x.y.Z`) | "Should be safe." Bug fixes, doc updates, operator-internal refactors with no CRD impact. |
+
+Key implementation choices:
+
+- **Tag format is unchanged** - releases stay `vX.Y.Z`, SemVer-shaped, because Helm chart versions and GitHub Releases expect that shape. Only the *interpretation* of the digits changes, and it changes in the docs.
+- **The leading `0` still signals early development.** While MACRO is `0`, even a MESO or MICRO bump may cost more effort than the digit implies; EffVer's `0.x` convention says exactly this. That makes the `-alpha.N` pre-release ladder redundant, so we drop it: `v0.1.0` is the first EffVer-governed cut, with no `-alpha`/`-beta` suffix on the stable line. Release candidates (`-rc.N`) may still be used for a pre-cut dry run.
+- **The nebari-app library chart inherits the operator's version** (lockstep, per ADR-002). A consumer's chart-upgrade effort is therefore read from the same EffVer digit as the operator upgrade; the chart carries no separate effort signal.
+- **Maintainer docs are the source of truth for interpretation** - `release-process.md`, `release-setup.md`, and `release-checklist.md` describe the effort rubric rather than pointing at semver.org.
+
+## Consequences
+
+### Positive
+
+- The version number answers the question consumers actually ask: "do I need to read the release notes, or can I just bump?"
+- Honest signal during pre-stable: shipping a routine CRD field change no longer forces a choice between an inflated major number and a spec violation.
+- Maps cleanly onto the NebariApp contract: a MACRO bump is precisely "your `NebariApp` manifests may need edits," which is the migration work pack authors care about.
+
+### Negative / Mitigations
+
+| Consequence | Mitigation |
+|-------------|------------|
+| EffVer is less widely known than SemVer; readers may assume SemVer semantics | Link the spec and carry the rubric table in every maintainer doc that mentions versioning |
+| Tooling and consumers may parse `vX.Y.Z` as SemVer and infer a compatibility promise EffVer does not make | Tag shape stays SemVer-valid so tooling keeps working; the compatibility interpretation is documented, and release notes call out MACRO effort explicitly |
+| Dropping `-alpha` removes an at-a-glance "not stable yet" cue | The leading `0.` MACRO carries that signal under EffVer, and the README states the pre-1.0 stability caveat in prose |
+
+## Alternatives considered
+
+### A — Effort-based Versioning (EffVer) (chosen)
+
+Reinterpret `MACRO.MESO.MICRO` as adoption effort. Fits a pre-1.0 project with an evolving CRD and a consumer base (pack authors) whose real question is upgrade cost, not API-compatibility theory. Chosen.
+
+### B — Strict Semantic Versioning
+
+Keep semver.org semantics. Rejected: pre-1.0 with a moving CRD, nearly every shippable change is "breaking," forcing either a meaningless major-number sprint or repeated spec violations on minor bumps - the exact drift the alpha line already showed.
+
+### C — Calendar Versioning (CalVer)
+
+Version by date (e.g. `2026.8.0`). Rejected: it communicates recency, not adoption effort or CRD-shape stability, leaving the consumer's core question - "how much work is this upgrade" - unanswered.

--- a/docs/maintainers/release-checklist.md
+++ b/docs/maintainers/release-checklist.md
@@ -30,7 +30,7 @@ git pull origin main
 ### 2. Create and push the release tag
 
 ```bash
-# Create a tag (use semantic versioning)
+# Create a tag (EffVer; see ADR-003 for how to pick the number)
 git tag -a v1.2.3 -m "Release v1.2.3"
 
 # Push the tag to trigger the release workflow
@@ -175,4 +175,4 @@ gh release create v1.2.4 --generate-notes
 
 - [Release Process Documentation](./release-process.md)
 - [Makefile Reference](../makefile-reference.md)
-- [Semantic Versioning](https://semver.org/)
+- [Effort-based Versioning (EffVer)](https://jacobtomlinson.dev/effver/)

--- a/docs/maintainers/release-process.md
+++ b/docs/maintainers/release-process.md
@@ -34,7 +34,7 @@ Before creating a release, ensure you have:
    - Manifests are up to date (`make manifests`)
    - Documentation is updated
 
-3. **Version Tagging Strategy**: Follow semantic versioning (e.g., `v1.0.0`, `v1.2.3`)
+3. **Version Tagging Strategy**: Follow EffVer (see [ADR-003](../decisions/2026-08-14-adopt-effver.md)); tags stay `vX.Y.Z`-shaped (e.g., `v0.1.0`, `v0.2.1`)
 
 ## Creating a Release
 
@@ -200,25 +200,25 @@ tar -xzf nebari-operator_1.0.0_Darwin_arm64.tar.gz
 
 ## Version Numbering
 
-Follow [Semantic Versioning](https://semver.org/):
+Follow [Effort-based Versioning (EffVer)](https://jacobtomlinson.dev/effver/) - `MACRO.MESO.MICRO`, where each digit signals the effort a consumer should expect when adopting the release (see [ADR-003](../decisions/2026-08-14-adopt-effver.md)):
 
-- **MAJOR** version (`vX.0.0`): Incompatible API changes
-- **MINOR** version (`v1.X.0`): Backward-compatible functionality additions
-- **PATCH** version (`v1.0.X`): Backward-compatible bug fixes
+- **MACRO** (`vX.0.0`): "Expect significant changes." CRD shape moved meaningfully; consumers will touch their pack manifests.
+- **MESO** (`v0.X.0`): "Could break, watch for warnings." New fields, optional opt-ins, deprecations.
+- **MICRO** (`v0.0.X`): "Should be safe." Bug fixes, doc updates, operator-internal refactors with no CRD impact.
+
+While MACRO is `0` the project is pre-stable: even a MESO or MICRO bump may cost more effort than the digit implies. Tags stay `vX.Y.Z` (SemVer-shaped) so Helm and GitHub Releases parse them; only the interpretation is EffVer.
 
 ### Examples:
 
-- `v1.0.0` - Initial stable release
-- `v1.1.0` - Added new features, backward compatible
-- `v1.1.1` - Bug fixes, no new features
-- `v2.0.0` - Breaking changes, requires migration
+- `v0.1.0` - First EffVer-governed release (graduating from the alpha line)
+- `v0.1.1` - Bug fixes or docs, no CRD impact (MICRO)
+- `v0.2.0` - New optional CRD fields or deprecations (MESO)
+- `v1.0.0` - Stable line begins; effort semantics are now trustworthy
 
 ### Pre-releases:
 
-You can also create pre-releases for testing:
-- `v1.0.0-alpha.1` - Alpha release
-- `v1.0.0-beta.1` - Beta release
-- `v1.0.0-rc.1` - Release candidate
+You can cut a release candidate as a pre-cut dry run (the `-alpha`/`-beta` ladder is retired under EffVer - see [ADR-003](../decisions/2026-08-14-adopt-effver.md)):
+- `v0.1.0-rc.1` - Release candidate
 
 To mark a release as a pre-release in GitHub, check the "This is a pre-release" checkbox.
 
@@ -349,7 +349,7 @@ Manually upload the files to the GitHub Release:
 
 1. **Test Before Release**: Always run tests locally before creating a release
 2. **Write Good Release Notes**: Clearly document what changed
-3. **Follow Semantic Versioning**: Be consistent with version numbers
+3. **Follow EffVer**: Pick the digit by adoption effort, not strict API compatibility (see [ADR-003](../decisions/2026-08-14-adopt-effver.md))
 4. **Announce Breaking Changes**: Clearly communicate incompatible changes
 5. **Maintain Changelog**: Keep CHANGELOG.md updated
 6. **Tag Appropriately**: Use annotated tags with descriptions
@@ -378,6 +378,6 @@ After a successful release:
 
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [GoReleaser Documentation](https://goreleaser.com/)
-- [Semantic Versioning](https://semver.org/)
+- [Effort-based Versioning (EffVer)](https://jacobtomlinson.dev/effver/)
 - [Kubebuilder Book](https://book.kubebuilder.io/)
 - [Quay.io Documentation](https://docs.quay.io/)

--- a/docs/maintainers/release-setup.md
+++ b/docs/maintainers/release-setup.md
@@ -233,16 +233,14 @@ The workflow uses the following environment variables:
 
 ## Versioning Strategy
 
-We follow [Semantic Versioning](https://semver.org/):
+We follow [Effort-based Versioning (EffVer)](https://jacobtomlinson.dev/effver/) - the `MACRO.MESO.MICRO` digits signal adoption effort, not strict API compatibility (see [ADR-003](../decisions/2026-08-14-adopt-effver.md)):
 
-- **v1.0.0** - Major version (breaking changes)
-- **v1.1.0** - Minor version (new features, backward compatible)
-- **v1.1.1** - Patch version (bug fixes)
+- **vX.0.0** - MACRO: expect significant changes; consumers touch their pack manifests
+- **v0.X.0** - MESO: could break, watch for warnings (new fields, opt-ins, deprecations)
+- **v0.0.X** - MICRO: should be safe (bug fixes, docs, no CRD impact)
 
-Pre-release versions:
-- **v1.0.0-alpha.1** - Alpha release
-- **v1.0.0-beta.1** - Beta release
-- **v1.0.0-rc.1** - Release candidate
+The `-alpha`/`-beta` ladder is retired: while MACRO is `0` the leading zero already signals pre-stable. Release candidates may still be cut for a pre-release dry run:
+- **v0.1.0-rc.1** - Release candidate
 
 ## Testing the Release
 
@@ -346,7 +344,7 @@ Commit → Tag → Release → Workflow Triggered
 
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [GoReleaser Documentation](https://goreleaser.com/)
-- [Semantic Versioning](https://semver.org/)
+- [Effort-based Versioning (EffVer)](https://jacobtomlinson.dev/effver/)
 - [Docker Build Push Action](https://github.com/docker/build-push-action)
 - [Quay.io Documentation](https://docs.quay.io/)
 


### PR DESCRIPTION
Adopts Effort-based Versioning (EffVer) as the operator's versioning policy, per the plan in #129.

## What changed

- **ADR-003** (`docs/decisions/2026-08-14-adopt-effver.md`) - records the switch from SemVer to EffVer, the MACRO/MESO/MICRO effort rubric (reused from #129), why EffVer fits a pre-1.0 project with an evolving CRD, the decision to drop the `-alpha`/`-beta` ladder (the leading `0.` already signals pre-stable), and the lockstep note that the nebari-app chart inherits the operator's version. Alternatives considered: SemVer, CalVer.
- **`docs/maintainers/release-process.md`, `release-setup.md`, `release-checklist.md`** - replace the SemVer framing with the EffVer effort rubric; retire the alpha/beta pre-release ladder (keep `-rc.N` for dry runs); point references at the EffVer spec.
- **`README.md`** - soften the "may change without notice" status line into a concrete EffVer statement (watch the MACRO digit for manifest-affecting upgrades).

## Scope

Docs-only; no code or workflow changes. Tag format stays `vX.Y.Z`, so release tooling is unaffected - only the interpretation of the digits changes.

This is the versioning slice of #129. It does not itself cut `v0.1.0`; the actual graduation is still gated by that issue's checklist. The stale release-checklist job-name list called out in #129 is left for that issue's dedicated pass to keep this PR scoped.

Refs #129.
