### PR TITLE
ci(build-pr): skip image build & push when no image-affecting files change

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -32,6 +32,26 @@ env:
   IMAGE_NAME: nebari/nebari-operator
 
 jobs:
+  changes:
+    name: Detect image-affecting changes
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.filter.outputs.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            image:
+              - '**.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Dockerfile'
+
   lint:
     name: Lint and Validate
     runs-on: ubuntu-latest
@@ -277,7 +297,8 @@ jobs:
   build-multiarch:
     name: Build & Push (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
-    needs: [test-chart, test, test-e2e]
+    needs: [changes, test-chart, test, test-e2e]
+    if: needs.changes.outputs.image == 'true'
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Problem

The `PR Checks` workflow (`build-pr.yml`) has a workflow-wide `paths` filter that includes `Makefile`. Because the filter is workflow-level (not per-job), **any** `Makefile` edit triggers the *entire* pipeline - including `build-multiarch`, which builds and **pushes** multi-arch images to Quay (`push: true`, `push-by-digest`), plus `merge-manifest` (creates and pushes the branch-tagged manifest) and `comment-pr`.

A `Makefile`-only change does not alter the operator binary or its container image. #175 is the concrete case: it added `helm-test` targets to the `Makefile` (and touched a Helm library template), changed nothing that goes into the image, and still spent a full `linux/amd64` + `linux/arm64` build-and-push cycle and published a `fix-nebari-app-required-guards`-tagged image to Quay for nothing.

## Change

Add a lightweight `changes` job (`dorny/paths-filter`) that flags whether any file that actually lands in the image changed:

```
image:
  - '**.go'
  - 'go.mod'
  - 'go.sum'
  - 'Dockerfile'
```

`build-multiarch` now carries `if: needs.changes.outputs.image == 'true'`. `merge-manifest` and `comment-pr` depend on `build-multiarch`, so they skip along with it.

`lint`, `test`, `test-e2e`, and `test-chart` are intentionally **not** gated - a `Makefile` edit can legitimately break `make test`, `make helm-chart`, etc., so those still run on every triggering change. Only the build-and-push to Quay is skipped when nothing image-affecting changed.

## Test plan

- YAML parses; `build-multiarch.needs` now includes `changes` and the `if` references `needs.changes.outputs.image`.
- On this PR (workflow-only change): lint/test/test-chart run as before; `build-multiarch`/`merge-manifest`/`comment-pr` should show as **skipped** in the checks, confirming no image is pushed.
- A follow-up PR that touches a `.go` file (or `Dockerfile`/`go.mod`/`go.sum`) will still build and push as today.

## Notes

There's a second, related gap worth a separate look: chart-template changes (`charts/**` / the generated `dist/chart`) aren't in the trigger `paths` at all, so Helm-template edits currently get no PR CI. Not addressed here to keep this change focused on the wasteful-push problem; can file an issue if useful.
