### PR TITLE
ci(release): pin Helm to v3.19.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,10 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: 'latest'
+          # Pin to Helm 3.x: setup-helm's "latest" now installs Helm 4, whose
+          # chart rendering/packaging differs from the Helm 3 the charts target.
+          # A deliberate Helm 4 migration is tracked separately.
+          version: v3.19.0
 
       - name: Install kubebuilder
         run: |
@@ -177,7 +180,10 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: 'latest'
+          # Pin to Helm 3.x: setup-helm's "latest" now installs Helm 4, whose
+          # chart rendering/packaging differs from the Helm 3 the charts target.
+          # A deliberate Helm 4 migration is tracked separately.
+          version: v3.19.0
 
       - name: Install kubebuilder
         run: |


### PR DESCRIPTION
## Problem

`azure/setup-helm@v5` with `version: 'latest'` now resolves to **Helm 4** (v4.2.4 as of writing). The repo's charts and golden tests are authored against **Helm 3**, and Helm 4 changes chart rendering/packaging output (e.g. trailing newlines in multi-document `helm template`). This already surfaced as a spurious `nebari-app` golden mismatch in `build-pr.yml`, which was pinned to `v3.19.0` when #180 landed.

`release.yml` still had two `setup-helm@v5` steps on `version: 'latest'`, so a release would build and publish charts with Helm 4 output while everything is tested on Helm 3.

## Change

Pin both `setup-helm` steps in `release.yml` to `version: v3.19.0`, matching `build-pr.yml`, so published charts are built with the same Helm the repo tests with.

`test-chart.yml` is **not** changed: it installs Helm via the `get-helm-3` script, which already tracks the latest Helm 3, so it is unaffected.

## Notes

This is the defensive, minimal fix. The real long-term direction is a deliberate **Helm 4 migration** - regenerate the `nebari-app` goldens under Helm 4, verify the operator chart builds and lints on Helm 4, then move the pins forward (or drop them). That is out of scope here; worth a tracking issue.

## Test plan

- `release.yml` parses as valid YAML; both `setup-helm` steps now read `version: v3.19.0`, the goreleaser `~> v2` version is untouched.
- No behavior change until the next release runs; the pin only fixes the Helm version used to package/publish the chart.
