### PR TITLE
template values for library chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,9 +222,9 @@ helm-lint: helm-lint-library ## Lint the helm charts
 .PHONY: helm-test-generate-golden
 helm-test-generate-golden: ## Generate golden files for nebari-app chart tests.
 	@command -v helm >/dev/null 2>&1 || { echo >&2 "helm is required but not installed. See https://helm.sh/docs/intro/install/"; exit 1; }
-	helm dependency build test/helm/nebari-app >/dev/null
+	helm dependency build --skip-refresh test/helm/nebari-app >/dev/null
 	mkdir -p test/helm/nebari-app/golden
-	@for c in minimal static multi; do \
+	@for c in minimal static multi templating; do \
 		helm template t test/helm/nebari-app --set cases.$$c.enabled=true > test/helm/nebari-app/golden/$$c.yaml; \
 		echo "  case $$c: golden written"; \
 	done
@@ -233,9 +233,9 @@ helm-test-generate-golden: ## Generate golden files for nebari-app chart tests.
 .PHONY: helm-test
 helm-test: helm-lint-library ## Render the nebari-app library chart for all cases and verify against golden files.
 	@command -v helm >/dev/null 2>&1 || { echo >&2 "helm is required but not installed. See https://helm.sh/docs/intro/install/"; exit 1; }
-	helm dependency build test/helm/nebari-app >/dev/null
+	helm dependency build --skip-refresh test/helm/nebari-app >/dev/null
 	@workdir=$$(mktemp -d); \
-	for c in minimal static multi; do \
+	for c in minimal static multi templating; do \
 		helm template t test/helm/nebari-app --set cases.$$c.enabled=true > $$workdir/$$c.yaml; \
 		diff -q test/helm/nebari-app/golden/$$c.yaml $$workdir/$$c.yaml >/dev/null \
 			|| { echo >&2 "case $$c: golden mismatch"; diff test/helm/nebari-app/golden/$$c.yaml $$workdir/$$c.yaml; rm -rf $$workdir; exit 1; }; \

--- a/charts/nebari-app/README.md
+++ b/charts/nebari-app/README.md
@@ -1,10 +1,6 @@
 # nebari-app
 
-A [library](https://helm.sh/docs/chart_template_guide/getting_started/#the-chart-yaml-file) Helm chart providing a reusable named template for rendering `NebariApp` custom resource instances.
-
-The chart exposes one named template, `nebari-app.nebariApp`, that acts as a pure function: callers pass `metadata` and `spec` dicts and the template renders a `NebariApp` resource. It is not installable on its own — it is consumed as a [chart dependency](https://helm.sh/docs/helm/helm_dependency/).
-
-> New here? For a step-by-step, end-to-end walkthrough (dependency → values → template → apply → verify), start with [Onboarding an app with the nebari-app Helm chart](../../docs/using-the-nebari-app-chart.md). This README is the reference for the template contract itself.
+A [library](https://helm.sh/docs/chart_template_guide/getting_started/#the-chart-yaml-file) Helm chart providing reusable templates for rendering `NebariApp` custom resource instances.
 
 ## Install as a dependency
 
@@ -13,7 +9,7 @@ Add the chart to your consumer chart's `Chart.yaml`:
 ```yaml
 dependencies:
   - name: nebari-app
-    version: ">=0.1.0-0"
+    version: ">=0.1.0"
     repository: oci://quay.io/nebari/charts
 ```
 
@@ -22,17 +18,70 @@ or via a local file path during development:
 ```yaml
 dependencies:
   - name: nebari-app
-    version: ">=0.1.0-0"
+    version: ">=0.1.0"
     repository: file://../nebari-app
 ```
 
 then run `helm dependency build`.
 
-## Usage
+## Templates
 
-The template takes a dict with `metadata` and `spec` keys:
+| Template | Description |
+|----------|-------------|
+| [`nebari-app.nebariApp`](#nebari-appnebariapp) | Renders a complete `NebariApp` resource from `metadata` and `spec` dicts |
+| [`nebari-app.deepTplJson`](#nebari-appdeeptpljson) | Applies template expansion to all strings in a nested structure, automatically parsing JSON outputs |
+
+> New here? For a step-by-step, end-to-end walkthrough (dependency → values → template → apply → verify), start with [Onboarding an app with the nebari-app Helm chart](../../docs/using-the-nebari-app-chart.md). This README is the reference for the template contracts.
+
+### nebari-app.nebariApp
+
+Renders a complete `NebariApp` custom resource.
+
+#### Usage
 
 ```yaml
+{{ include "nebari-app.nebariApp" (dict "metadata" $metadata "spec" $spec "ctx" $ctx) }}
+```
+
+#### Parameters
+
+- `$metadata`: Metadata mapping, such as name, namespace, and labels. Templates will be expanded using [`nebari-app.deepTplJson`](#nebari-appdeeptpljson).
+- `$spec`: `NebariApp` CR specification. Templates will be expanded using [`nebari-app.deepTplJson`](#nebari-appdeeptpljson).
+- `$ctx`: Optional templating context. If omitted, an empty context is used.
+
+#### Required fields
+
+The template enforces the presence of the following fields
+
+- `$metadata.name`
+- `$spec.hostname`
+- `$spec.service.name`
+- `$spec.service.port`
+
+as well as additionally the validity if the following fields
+
+- `$spec.service.port`
+
+All other validation (the rest of the `NebariAppSpec` schema) happens API-server-side at apply time. To catch schema errors before deployment, pipe `helm template` output through `kubectl apply --dry-run=server -f -`. This requires a cluster with the NebariApp CRD installed.
+
+#### Dynamic defaults
+
+The template uses `nebari-app.deepTplJson` internally to render both `$metadata` and `$spec`. This means you can embed template expressions directly in your values, and they will be expanded at render time:
+
+```yaml
+# values.yaml
+service:
+  port: 80
+
+nebariApp:
+  hostname: "{{ printf "%s.example.com" .Release.Name }}"
+  service:
+    name: "{{ printf "%s-service" .Release.Name }}"
+    port: "{{ .Values.service.port }}"
+```
+
+```yaml
+# template.yaml
 {{ include "nebari-app.nebariApp" (dict
     "metadata" (dict
       "name"      .Release.Name
@@ -40,42 +89,11 @@ The template takes a dict with `metadata` and `spec` keys:
       "labels"    (dict "app.kubernetes.io/name" .Chart.Name)
     )
     "spec" .Values.nebariApp
+    "ctx"  .
 ) }}
 ```
 
-### Required fields
-
-The template enforces these required fields via Helm's `required` function (render aborts if any is missing or empty):
-
-- `metadata.name`
-- `spec.hostname`
-- `spec.service.name`
-- `spec.service.port`
-
-All other validation (the rest of the `NebariAppSpec` schema) happens API-server-side at apply time. To catch schema errors before deployment, pipe `helm template` output through `kubectl apply --dry-run=server -f -`. This requires a cluster with the NebariApp CRD installed.
-
-### Dynamic service values
-
-When `spec.service.name` is derived (e.g. from a component name) rather than static, use `mergeOverwrite` to layer computed values under the consumer's static values:
-
-```yaml
-{{ include "nebari-app.nebariApp" (dict
-    "metadata" (dict
-      "name"      "frontend"
-      "namespace" .Release.Namespace
-    )
-    "spec" (mergeOverwrite (dict
-        "service" (dict
-          "name" "frontend"
-          "port" .Values.frontend.service.port
-        )
-      ) .Values.frontend.nebariApp)
-) }}
-```
-
-`mergeOverwrite` gives precedence to its **second argument**, so consumer values override the computed defaults on overlapping keys; the computed `service.name`/`service.port` fill in the gaps.
-
-### Multiple NebariApps from one chart
+#### Multiple NebariApps from one chart
 
 To avoid repeating `metadata` construction at every call site, define a thin consumer-owned wrapper template that builds `metadata` from `top` and `component` and forwards `spec`:
 
@@ -96,13 +114,37 @@ To avoid repeating `metadata` construction at every call site, define a thin con
 Then each call site passes only `top`, `component`, and `spec`:
 
 ```yaml
-{{ include "mychart.nebariApp" (dict "top" . "component" "frontend" "spec" .Values.frontend.nebariApp) }}
+{{ include "mychart.nebariApp" (dict "top" . "component" "frontend" "spec" .Values.nebariApp) }}
 ```
 
-## Namespace requirement
+#### Namespace requirement
 
-The Nebari operator only reconciles `NebariApp` resources whose target namespace carries the label `nebari.dev/managed=true`. This chart does not template that label — ensure the namespace is opted in separately (e.g. via a `Namespace` resource in your consumer chart).
+The Nebari operator only reconciles `NebariApp` resources whose target namespace carries the label `nebari.dev/managed=true`. This chart does not template that label. Ensure the namespace is opted in separately (e.g. via a `Namespace` resource in your consumer chart).
 
-## Field reference
+### nebari-app.deepTplJson
 
-The canonical reference for all `spec` fields is [docs/api-reference.md](../../docs/api-reference.md), auto-generated from the Go types. See also [docs/configuration-reference.md](../../docs/configuration-reference.md) for examples and usage guidance.
+Apply template expansion to all strings in a nested structure, automatically parsing JSON outputs. This is useful for embedding dynamic values (computed at render time) directly in your values, eliminating the need for manual merging patterns.
+
+#### Usage
+
+```yaml
+{{ include "nebari-app.deepTplJson" (dict "ctx" $ctx "value" $value) | fromJson }}
+```
+
+#### Parameters
+
+- `$ctx`: Context for template rendering.
+- `$value`: Arbitrarily nested structure.
+
+#### Behavior
+
+- Recursively traverses maps and slices
+- Applies `tpl` to all strings
+- If a template output is valid JSON, parses it and uses the parsed value
+- Returns JSON string of the fully rendered structure
+
+#### Example
+
+```yaml
+{{ include "nebari-app.deepTplJson" (dict "ctx" . "value" .Values.config) | fromJson }}
+```

--- a/charts/nebari-app/templates/_helpers.tpl
+++ b/charts/nebari-app/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{- define "nebari-app.internal.deepTplJson" -}}
+{{- $ctx := .ctx -}}
+{{- $value := .value -}}
+{{- $tplValue := "" -}}
+
+{{- /* maps: recursively template keys and values */ -}}
+{{- if kindIs "map" $value -}}
+    {{- $tplValue = dict -}}
+    {{- range $k, $v := $value -}}
+    {{- $_ := set $tplValue (tpl $k $ctx) (include "nebari-app.internal.deepTplJson" (dict "ctx" $ctx "value" $v) | fromJson).tplValue -}}
+{{- end -}}
+
+{{- /* slices: recursively template elements */ -}}
+{{- else if kindIs "slice" $value -}}
+    {{- $tplValue = list -}}
+    {{- range $v := $value -}}
+    {{- $tplValue = append $tplValue (include "nebari-app.internal.deepTplJson" (dict "ctx" $ctx "value" $v) | fromJson).tplValue -}}
+{{- end -}}
+
+{{- /* strings: expand templates */ -}}
+{{- else if kindIs "string" $value -}}
+    {{- $tplValue = tpl $value $ctx -}}
+    {{- /* try parse output as JSON and use it if valid */ -}}
+    {{- $tplValueFromJson := (printf "{\"tplValue\": %s}" $tplValue | fromJson).tplValue -}}
+    {{- if $tplValueFromJson }}
+        {{- $tplValue = $tplValueFromJson -}}
+{{- end -}}
+
+{{- /* any other type: return as-is */ -}}
+{{- else -}}
+    {{- $tplValue = $value -}}
+{{- end -}}
+
+{{- dict "tplValue" $tplValue | toJson -}}
+{{- end -}}
+
+{{/*
+ Apply tpl to all strings in a nested structure.
+ 
+ If any template output is valid JSON, it is automatically parsed.
+
+ Usage:
+   {{ include "nebari-app.deepTplJson" (dict "ctx" $ctx "value" $value) }}
+
+ Parameters:
+   - $ctx: Context for template rendering.
+   - $value: Arbitrarily nested structure.
+
+ Returns:
+   JSON string of the rendered $value.
+
+ Example:
+   {{ include "nebari-app.deepTplJson" (dict "ctx" . "value" .Values.config) | fromJson }}
+*/}}
+{{- define "nebari-app.deepTplJson" -}}
+{{- $_ := required "ctx is required" .ctx -}}
+{{- $_ := required "value is required" .value -}}
+{{- (include "nebari-app.internal.deepTplJson" . | fromJson).tplValue | toJson  -}}
+{{- end -}}

--- a/charts/nebari-app/templates/_helpers.tpl
+++ b/charts/nebari-app/templates/_helpers.tpl
@@ -20,7 +20,9 @@
 {{- /* strings: expand templates */ -}}
 {{- else if kindIs "string" $value -}}
     {{- $tplValue = tpl $value $ctx -}}
-    {{- /* try parse output as JSON and use it if valid */ -}}
+    {{- /* Try parse output as JSON and use it if valid. */ -}}
+    {{- /* This is required for templates to return anything but plain strings. */ -}}
+    {{- /* At the same time we cannot hard-require JSON output, as we are also handling regular static strings without a template */ -}}
     {{- $tplValueFromJson := (printf "{\"tplValue\": %s}" $tplValue | fromJson).tplValue -}}
     {{- if $tplValueFromJson }}
         {{- $tplValue = $tplValueFromJson -}}
@@ -35,22 +37,22 @@
 {{- end -}}
 
 {{/*
- Apply tpl to all strings in a nested structure.
- 
- If any template output is valid JSON, it is automatically parsed.
+    Apply template expansion to all strings in a nested structure.
 
- Usage:
-   {{ include "nebari-app.deepTplJson" (dict "ctx" $ctx "value" $value) }}
+    If any template output is valid JSON, it is automatically parsed.
 
- Parameters:
-   - $ctx: Context for template rendering.
-   - $value: Arbitrarily nested structure.
+    Usage:
+        {{ include "nebari-app.deepTplJson" (dict "ctx" $ctx "value" $value) }}
 
- Returns:
-   JSON string of the rendered $value.
+    Parameters:
+        - $ctx: Context for template rendering.
+        - $value: Arbitrarily nested structure.
 
- Example:
-   {{ include "nebari-app.deepTplJson" (dict "ctx" . "value" .Values.config) | fromJson }}
+    Returns:
+        JSON string of the rendered $value.
+
+    Example:
+        {{ include "nebari-app.deepTplJson" (dict "ctx" . "value" .Values.config) | fromJson }}
 */}}
 {{- define "nebari-app.deepTplJson" -}}
 {{- $_ := required "ctx is required" .ctx -}}

--- a/charts/nebari-app/templates/_nebari-app.tpl
+++ b/charts/nebari-app/templates/_nebari-app.tpl
@@ -1,14 +1,17 @@
 {{- define "nebari-app.nebariApp" -}}
-{{- $_ := required "metadata.name is required" .metadata.name -}}
-{{- $_ := required "spec.hostname is required" .spec.hostname -}}
-{{- $_ := required "spec.service is required" .spec.service -}}
-{{- $_ := required "spec.service.name is required" .spec.service.name -}}
-{{- $_ := required "spec.service.port is required" .spec.service.port -}}
-{{- if lt (int .spec.service.port) 1 -}}{{- fail "spec.service.port must be >= 1" -}}{{- end -}}
+{{- $ctx := .ctx | default dict -}}
+{{- $metadata := include "nebari-app.deepTplJson" (dict "ctx" $ctx "value" .metadata) | fromJson -}}
+{{- $_ := required "metadata.name is required" $metadata.name -}}
+{{- $spec := include "nebari-app.deepTplJson" (dict "ctx" $ctx "value" .spec) | fromJson -}}
+{{- $_ := required "spec.hostname is required" $spec.hostname -}}
+{{- $_ := required "spec.service is required" $spec.service -}}
+{{- $_ := required "spec.service.name is required" $spec.service.name -}}
+{{- $_ := required "spec.service.port is required" $spec.service.port -}}
+{{- if lt (int $spec.service.port) 1 -}}{{- fail "spec.service.port must be >= 1" -}}{{- end -}}
 apiVersion: reconcilers.nebari.dev/v1
 kind: NebariApp
 metadata:
-  {{- toYaml .metadata | nindent 2 }}
+  {{- $metadata | toYaml | nindent 2 }}
 spec:
-  {{- toYaml .spec | nindent 2 }}
+  {{- $spec | toYaml | nindent 2 }}
 {{- end -}}

--- a/charts/nebari-app/templates/_nebari-app.tpl
+++ b/charts/nebari-app/templates/_nebari-app.tpl
@@ -11,7 +11,7 @@
 apiVersion: reconcilers.nebari.dev/v1
 kind: NebariApp
 metadata:
-  {{- $metadata | toYaml | nindent 2 }}
+  {{- toYaml $metadata | nindent 2 }}
 spec:
-  {{- $spec | toYaml | nindent 2 }}
+  {{- toYaml $spec | nindent 2 }}
 {{- end -}}

--- a/charts/nebari-app/templates/_nebari-app.tpl
+++ b/charts/nebari-app/templates/_nebari-app.tpl
@@ -1,3 +1,17 @@
+{{/*
+  Render a complete `NebariApp` custom resource.
+
+  Usage:
+    {{ include "nebari-app.nebariApp" (dict "metadata" $metadata "spec" $spec "ctx" $ctx) }}
+
+  Parameters:
+    - `$metadata`: Metadata mapping, such as name, namespace, and labels. Templates will be expanded using ebari-app.deepTplJson.
+    - `$spec`: `NebariApp` CR specification. Templates will be expanded using nebari-app.deepTplJson.
+    - `$ctx`: Optional templating context. If omitted, an empty context is used.
+
+  Returns:
+    rendered NebariApp CR.
+*/}}
 {{- define "nebari-app.nebariApp" -}}
 {{- $ctx := .ctx | default dict -}}
 {{- $metadata := include "nebari-app.deepTplJson" (dict "ctx" $ctx "value" .metadata) | fromJson -}}

--- a/docs/using-the-nebari-app-chart.md
+++ b/docs/using-the-nebari-app-chart.md
@@ -2,7 +2,7 @@
 
 This is a task-oriented walkthrough: it takes you from an empty chart to a running, operator-managed app using the [`nebari-app`](../charts/nebari-app) library chart. It packages the same `NebariApp` resource you write by hand in the [Quick Start](quickstart.md), so it is reusable, versioned, and shippable as a Nebari Software Pack.
 
-- For the **template contract and every option** (required fields, `mergeOverwrite`, multiple apps per chart), see the chart's own [`charts/nebari-app/README.md`](../charts/nebari-app/README.md).
+- For the **template contract and every option** (required fields, multiple apps per chart), see the chart's own [`charts/nebari-app/README.md`](../charts/nebari-app/README.md).
 - For **complete, copy-me examples** in several styles (raw YAML, Helm, Kustomize, wrapping an existing chart), see [`nebari-dev/software-pack-template`](https://github.com/nebari-dev/software-pack-template).
 
 This page is the connective tissue between those two: the end-to-end path, in order.
@@ -143,7 +143,7 @@ kubectl get httproute -n my-namespace
 
 ## Where to go next
 
-- [`charts/nebari-app/README.md`](../charts/nebari-app/README.md) — the full template contract: `mergeOverwrite` for computed service values, emitting multiple `NebariApp`s from one chart, and the exact required-field list.
+- [`charts/nebari-app/README.md`](../charts/nebari-app/README.md) — the full template contract: emitting multiple `NebariApp`s from one chart, and the exact required-field list.
 - [docs/configuration-reference.md](configuration-reference.md) — every `spec` field with examples.
 - [docs/api-reference.md](api-reference.md) — the generated CRD reference.
 - [`nebari-dev/software-pack-template`](https://github.com/nebari-dev/software-pack-template) — complete runnable Software Packs to copy from.

--- a/test/helm/nebari-app/golden/templating.yaml
+++ b/test/helm/nebari-app/golden/templating.yaml
@@ -1,0 +1,41 @@
+---
+# Source: fixture/templates/templating.yaml
+apiVersion: reconcilers.nebari.dev/v1
+kind: NebariApp
+metadata:
+  labels:
+    app.kubernetes.io/instance: t
+    app.kubernetes.io/name: t
+    app.kubernetes.io/version: 1
+  name: test-t-app
+  namespace: default
+spec:
+  auth:
+    enabled: true
+    enforceAtGateway: false
+    provider: keycloak
+    provisionClient: true
+    redirectURI: /*
+    scopes:
+    - openid
+    - profile
+    - email
+  hostname: t.nebari.local
+  landingPage:
+    category: testing
+    description: App for t
+    displayName: T App
+    enabled: true
+    healthCheck:
+      enabled: true
+      path: /health
+    priority: 1
+  routing:
+    routes:
+    - pathPrefix: /
+      pathType: PathPrefix
+    - pathPrefix: /api
+      pathType: PathPrefix
+  service:
+    name: svc-t
+    port: 1

--- a/test/helm/nebari-app/templates/multi.yaml
+++ b/test/helm/nebari-app/templates/multi.yaml
@@ -1,13 +1,14 @@
 {{- if .Values.cases.multi.enabled }}
 {{- range $app := .Values.cases.multi.apps }}
-{{- $computedService := dict "name" $app.component "port" $app.servicePort -}}
-{{- $userService := $app.nebariApp.service | default dict -}}
-{{- $service := mergeOverwrite $computedService $userService -}}
-{{- $spec := mergeOverwrite (dict "service" $service) $app.nebariApp -}}
 {{- include "fixture.nebariApp" (dict
     "top" $
     "component" $app.component
-    "spec" $spec
+    "spec" (mergeOverwrite (dict
+        "service" (dict
+          "name" $app.component
+          "port" $app.servicePort
+        )
+      ) $app.nebariApp)
 ) }}
 ---
 {{- end }}

--- a/test/helm/nebari-app/templates/multi.yaml
+++ b/test/helm/nebari-app/templates/multi.yaml
@@ -1,14 +1,13 @@
 {{- if .Values.cases.multi.enabled }}
 {{- range $app := .Values.cases.multi.apps }}
+{{- $computedService := dict "name" $app.component "port" $app.servicePort -}}
+{{- $userService := $app.nebariApp.service | default dict -}}
+{{- $service := mergeOverwrite $computedService $userService -}}
+{{- $spec := mergeOverwrite (dict "service" $service) $app.nebariApp -}}
 {{- include "fixture.nebariApp" (dict
     "top" $
     "component" $app.component
-    "spec" (mergeOverwrite (dict
-        "service" (dict
-          "name" $app.component
-          "port" $app.servicePort
-        )
-      ) $app.nebariApp)
+    "spec" $spec
 ) }}
 ---
 {{- end }}

--- a/test/helm/nebari-app/templates/templating.yaml
+++ b/test/helm/nebari-app/templates/templating.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.cases.templating.enabled }}
 {{ include "nebari-app.nebariApp" (dict
-    "ctx"      $
+    "ctx"      .
     "metadata" .Values.cases.templating.metadata
     "spec"     .Values.cases.templating.spec
 ) }}

--- a/test/helm/nebari-app/templates/templating.yaml
+++ b/test/helm/nebari-app/templates/templating.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.cases.templating.enabled }}
+{{ include "nebari-app.nebariApp" (dict
+    "ctx"      $
+    "metadata" .Values.cases.templating.metadata
+    "spec"     .Values.cases.templating.spec
+) }}
+{{- end }}

--- a/test/helm/nebari-app/values.yaml
+++ b/test/helm/nebari-app/values.yaml
@@ -78,9 +78,9 @@ cases:
         nebariApp:
           hostname: api.nebari.local
           # Consumer sets service.name, which overlaps the computed value
-          # (the component name "api"). The test template merges the computed
-          # service defaults with this nebariApp block, so "api-external"
-          # survives while the computed service.port (8000) fills the gap.
+          # (the component name "api"). mergeOverwrite gives precedence to
+          # its second argument (this nebariApp block), so "api-external"
+          # must survive while the computed service.port (8000) fills the gap.
           service:
             name: api-external
           routing:
@@ -112,11 +112,7 @@ cases:
           - '{{ "PROFILE" | lower }}'
           - email
       routing:
-        routes:
-          - pathPrefix: /
-            pathType: PathPrefix
-          - pathPrefix: /api
-            pathType: PathPrefix
+        routes: '{{ $routes := list }}{{ range (list "/" "/api") }}{{ $routes = append $routes (dict "pathPrefix" . "pathType" "PathPrefix") }}{{ end }}{{ $routes | toJson }}'
       landingPage:
         enabled: true
         displayName: "{{ .Release.Name | title }} App"

--- a/test/helm/nebari-app/values.yaml
+++ b/test/helm/nebari-app/values.yaml
@@ -87,3 +87,42 @@ cases:
             routes:
               - pathPrefix: /
                 pathType: PathPrefix
+  templating:
+    enabled: false
+    metadata:
+      name: "test-{{ .Release.Name }}-app"
+      namespace: default
+      labels:
+        app.kubernetes.io/name: "{{ .Release.Name }}"
+        app.kubernetes.io/version: "1.0"
+        app.kubernetes.io/instance: t
+    spec:
+      hostname: "{{ .Release.Name }}.nebari.local"
+      service:
+        name: "svc-{{ .Release.Name }}"
+        port: '{{ .Values.cases.minimal.spec.service.port }}'
+      auth:
+        enabled: true
+        provider: keycloak
+        provisionClient: true
+        enforceAtGateway: false
+        redirectURI: /*
+        scopes:
+          - openid
+          - '{{ "PROFILE" | lower }}'
+          - email
+      routing:
+        routes:
+          - pathPrefix: /
+            pathType: PathPrefix
+          - pathPrefix: /api
+            pathType: PathPrefix
+      landingPage:
+        enabled: true
+        displayName: "{{ .Release.Name | title }} App"
+        description: "App for {{ .Release.Name }}"
+        category: testing
+        priority: 1
+        healthCheck:
+          enabled: true
+          path: /health

--- a/test/helm/nebari-app/values.yaml
+++ b/test/helm/nebari-app/values.yaml
@@ -78,9 +78,9 @@ cases:
         nebariApp:
           hostname: api.nebari.local
           # Consumer sets service.name, which overlaps the computed value
-          # (the component name "api"). mergeOverwrite gives precedence to
-          # its second argument (this nebariApp block), so "api-external"
-          # must survive while the computed service.port (8000) fills the gap.
+          # (the component name "api"). The test template merges the computed
+          # service defaults with this nebariApp block, so "api-external"
+          # survives while the computed service.port (8000) fills the gap.
           service:
             name: api-external
           routing:


### PR DESCRIPTION
## Issue

TL;DR

- NebariApp spec values like hostname or service configuration often need dynamically computed default values
- Computation can only happens as part of templates
- There is no good native way in helm to blend static and dynamic default values to pass them on as arguments to a template

## What does this implement/fix?

TL;DR

- reusable `deepTplJson` template that recursively applies the [`tpl` function](https://helm.sh/docs/v3/howto/charts_tips_and_tricks/#using-the-tpl-function) to all strings in a nested structure
- usage of `deepTplJson` for the metadata and spec of the `nebariApp` template to allow dynamically computed default values natively

---

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

